### PR TITLE
Grouping evidence across edges

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,13 +65,15 @@ python src/gocam_unwinder/gocam_ttl.py \
 
 ### Core Components
 
-**GoCamGraph** (`src/gocam_unwinder/gocam_ttl.py:70-298`)
+**GoCamGraph** (`src/gocam_unwinder/gocam_ttl.py:72-430`)
 - Main data structure representing a GO-CAM model
 - Wraps an rdflib.Graph and extracts structured annotation information
 - Key methods:
   - `parse_ttl()`: Class method to parse a TTL file into a GoCamGraph
   - `extract_standard_annotations()`: Identifies and groups connected edges into StandardAnnotation objects
-  - `split_evidence_and_write_ttl()`: Duplicates edges with multiple evidence nodes
+  - `get_evidence_metadata()`: Extracts metadata signature from evidence individuals for grouping
+  - `group_evidence_by_metadata()`: Groups evidence across edges by identical metadata
+  - `split_evidence_and_write_ttl()`: Splits multi-evidence annotations by evidence groups
   - `filter_out_non_std_annotations()`: Filters based on structural patterns
 
 **StandardAnnotation** (`src/gocam_unwinder/gocam_ttl.py:43-68`)
@@ -86,14 +88,14 @@ python src/gocam_unwinder/gocam_ttl.py \
   - List of evidence URIs
   - Source and target types (GO terms, etc.)
 
-**GoCamGraphBuilder** (`src/gocam_unwinder/gocam_ttl.py:300-347`)
+**GoCamGraphBuilder** (`src/gocam_unwinder/gocam_ttl.py:432-478`)
 - Factory class that parses GO-CAM models with GO ontology context
 - Uses ontobio's GoAspector to determine if terms are molecular functions
 - Filters out non-standard annotations based on aspect logic (multiple part_of edges from molecular functions)
 
 ### Key Algorithm: Standard Annotation Extraction
 
-The `extract_standard_annotations()` method (lines 212-272) implements a union-find-like algorithm:
+The `extract_standard_annotations()` method (lines 344-403) implements a union-find-like algorithm:
 
 1. Iterates through all edges with evidence
 2. Tracks which StandardAnnotation each individual URI belongs to via `individual_to_annotation` dict
@@ -107,23 +109,54 @@ This ensures that all edges sharing individuals or transitively connected throug
 
 ### Evidence Splitting Logic
 
-The `split_evidence_and_write_ttl()` method (lines 100-123) handles the "unwinding":
+The evidence splitting process now groups evidence by metadata to handle multi-edge annotations correctly (Issue #6):
 
-1. For each edge with multiple evidence URIs (sorted for determinism):
-   - First evidence: keeps the original blank node and individuals
-   - Subsequent evidences: creates new blank nodes with suffix "-2", "-3", etc.
-   - Creates new individual URIs with same suffix (e.g., "uri-2", "uri-3")
+#### Evidence Metadata Grouping
+
+The `get_evidence_metadata()` method (lines 102-127) extracts a metadata signature from each evidence individual:
+- Collects values for predicates in `PREDICATES_TO_COPY` (type, contributor, date, created, dateAccepted, providedBy, comment)
+- Also includes `evidence-with` and `source` predicates
+- Returns a hashable tuple that uniquely identifies evidence with identical metadata
+
+The `group_evidence_by_metadata()` method (lines 129-178) groups evidence across edges in a standard annotation:
+1. Collects metadata signatures for all evidence individuals in the annotation
+2. Groups evidence URIs by their metadata signature
+3. For each metadata group, identifies which evidence from each edge belongs to that group
+4. Returns a mapping: `group_index -> {edge_bnode_id -> [evidence_uris]}`
+
+This ensures that evidence representing the same "evidence event" across different edges stay together.
+
+#### Splitting Algorithm
+
+The `split_evidence_and_write_ttl()` method (lines 180-255) implements the actual splitting:
+
+1. For each standard annotation, get evidence groups via `group_evidence_by_metadata()`
+2. For each evidence group:
+   - Group 0 (first): keeps original blank nodes and individuals, removes extra evidence
+   - Groups 1+ (subsequent): creates new blank nodes with suffix "-2", "-3", etc.
+   - Creates new individual URIs with same suffix for all edges in the group
+   - Reuses individual URIs across edges in the same group (via `individual_mapping`)
    - Clones metadata (types, contributors, dates) to new nodes using `PREDICATES_TO_COPY`
-   - Removes extra evidence triples from original node
+   - Adds only the evidence belonging to this group
 
-This maintains provenance while ensuring one-to-one edge-to-evidence relationships.
+**Example:** If an annotation has 2 edges with evidence [A, B] and [C, D] respectively, where metadata(A) == metadata(C) and metadata(B) == metadata(D):
+- Group 0: Edge 1 with evidence A + Edge 2 with evidence C (original nodes)
+- Group 1: Edge 1 with evidence B + Edge 2 with evidence D (new nodes with "-2" suffix)
+
+This maintains provenance while ensuring one-to-one edge-to-evidence relationships and correct evidence grouping across edges.
 
 ### Testing
 
 Tests use real GO-CAM model examples in `resources/test/`:
 - **SGD_S000004491.ttl**: Standard yeast gene model (15 evidence triples, 3 edges)
 - **MGI_MGI_1335098.ttl**: Mouse model with occurs_in extensions (34 standard annotations)
+- **MGI_MGI_1100089.ttl**: Mouse Tnfsf11 model with multi-edge multi-evidence annotations (29 standard annotations)
 - **R-HSA-9937080.ttl**: Reactome pathway (should have 0 standard, 1 non-standard)
 - **SYNGO_5371.ttl**: SynGO model (1 standard annotation)
+- **61452e3d00000323.ttl**: Saccharomyces MAL loci model (10 standard annotations)
 
 The test requires the GO ontology file at `target/go_20250601.json` (downloaded via Makefile).
+
+**Test Functions:**
+- `test_gocam_ttl()`: Tests basic parsing, annotation extraction, and splitting for multiple models
+- `test_multi_edge_evidence_grouping()`: Tests evidence grouping logic for Issue #6, verifies that evidence with identical metadata across edges is properly grouped when splitting

--- a/resources/test/61452e3d00000323.ttl
+++ b/resources/test/61452e3d00000323.ttl
@@ -1,0 +1,904 @@
+
+<http://model.geneontology.org/61452e3d00000323> a <http://www.w3.org/2002/07/owl#Ontology> .
+
+<http://geneontology.org/lego/evidence> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://geneontology.org/lego/evidence-with> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://geneontology.org/lego/hint/layout/x> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://geneontology.org/lego/hint/layout/y> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://geneontology.org/lego/modelstate> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/ECO_0000250> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/ECO_0000315> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/RO_0002333> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.org/pav/providedBy> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<https://w3id.org/biolink/vocab/in_taxon> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/BFO_0000050> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.obolibrary.org/obo/BFO_0000066> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.obolibrary.org/obo/ECO_0000314> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0005634> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/ECO_0000307> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0005575> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0003700> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/ECO_0000316> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0005886> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0006355> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0016020> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/ECO_0000305> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0004558> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0005363> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/sgd/S000000501> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0000025> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/sgd/S000029657> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/sgd/S000029658> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/sgd/S000029659> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/sgd/S000029681> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/sgd/S000029682> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/sgd/S000029686> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/sgd/S000029687> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/sgd/S000029688> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/sgd/S000029690> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/61452e3d00000323> <http://geneontology.org/lego/modelstate> "production"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<https://w3id.org/biolink/vocab/in_taxon> <http://purl.obolibrary.org/obo/NCBITaxon_559292> ;
+	a <http://www.w3.org/2002/07/owl#Ontology> ;
+	<http://purl.org/dc/elements/1.1/title> "multigene family of MAL loci in Saccharomyces"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2024-06-14"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000329> <http://geneontology.org/lego/hint/layout/x> "3618.75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "381.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/61452e3d00000323/61452e3d00000330> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/61452e3d00000323/61452e3d00000331> ;
+	<http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/61452e3d00000323/61452e3d00000332> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005363> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2024-06-14"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000330> <http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000029681> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000331> <http://geneontology.org/lego/hint/layout/x> "3618.75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_1904981> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2024-06-14"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000332> <http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0016020> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000333> <http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:12702465"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000334> <http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:12702465"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000335> <http://geneontology.org/lego/evidence-with> "GO:0005363|GO:1904981"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000305> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:12702465"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000347> <http://geneontology.org/lego/hint/layout/x> "3225"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "381.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/61452e3d00000323/61452e3d00000348> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/61452e3d00000323/61452e3d00000349> ;
+	<http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/61452e3d00000323/61452e3d00000350> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005363> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2024-06-14"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000348> <http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000029658> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000349> <http://geneontology.org/lego/hint/layout/x> "3225"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_1904981> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2024-06-14"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000350> <http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005886> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000351> <http://geneontology.org/lego/evidence-with> "SGD:S000003521"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000316> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:1999393"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000352> <http://geneontology.org/lego/evidence-with> "SGD:S000003521"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000316> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:8594329"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000353> <http://geneontology.org/lego/evidence-with> "SGD:S000003521"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000316> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:6371820"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000354> <http://geneontology.org/lego/evidence-with> "SGD:S000003521"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000316> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:1999393"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000355> <http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:16741702"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000358> <http://geneontology.org/lego/hint/layout/x> "2831.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "381.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/61452e3d00000323/61452e3d00000359> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/61452e3d00000323/61452e3d00000360> ;
+	<http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/61452e3d00000323/61452e3d00000361> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005363> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2024-06-14"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000359> <http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000029686> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000360> <http://geneontology.org/lego/hint/layout/x> "2831.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_1904981> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2024-06-14"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000361> <http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005886> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000362> <http://geneontology.org/lego/evidence-with> "SGD:S000029658|SGD:S000029681"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://purl.obolibrary.org/obo/ECO_0000250> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:2549370"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000363> <http://geneontology.org/lego/evidence-with> "SGD:S000029658|SGD:S000029681"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://purl.obolibrary.org/obo/ECO_0000250> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:2549370"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000364> <http://geneontology.org/lego/evidence-with> "SGD:S000029658"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://purl.obolibrary.org/obo/ECO_0000250> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:2549370"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000377> <http://geneontology.org/lego/hint/layout/x> "2437.5"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "381.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/61452e3d00000323/61452e3d00000378> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/61452e3d00000323/61452e3d00000379> ;
+	<http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/61452e3d00000323/61452e3d00000380> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004558> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2024-06-14"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000378> <http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000029690> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000379> <http://geneontology.org/lego/hint/layout/x> "2437.5"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0000025> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2024-06-14"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000380> <http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005575> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000381> <http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:8636115"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000382> <http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:2993804"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000383> <http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:6371820"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000384> <http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000307> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "GO_REF:0000015"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000385> <http://geneontology.org/lego/hint/layout/x> "2043.75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "381.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/61452e3d00000323/61452e3d00000386> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/61452e3d00000323/61452e3d00000387> ;
+	<http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/61452e3d00000323/61452e3d00000388> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004558> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2024-06-14"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000386> <http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000029682> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000387> <http://geneontology.org/lego/hint/layout/x> "2043.75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0000025> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2024-06-14"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000388> <http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005575> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000389> <http://geneontology.org/lego/evidence-with> "SGD:S000000503"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://purl.obolibrary.org/obo/ECO_0000250> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:2549370"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000390> <http://geneontology.org/lego/evidence-with> "SGD:S000000503"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://purl.obolibrary.org/obo/ECO_0000250> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:2549370"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000391> <http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000307> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "GO_REF:0000015"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000392> <http://geneontology.org/lego/hint/layout/x> "1650"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "381.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/61452e3d00000323/61452e3d00000393> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/61452e3d00000323/61452e3d00000394> ;
+	<http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/61452e3d00000323/61452e3d00000395> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004558> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2024-06-14"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000393> <http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000029687> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000394> <http://geneontology.org/lego/hint/layout/x> "1650"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0000025> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2024-06-14"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000395> <http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005575> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000396> <http://geneontology.org/lego/evidence-with> "SGD:S000000503"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://purl.obolibrary.org/obo/ECO_0000250> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:2549370"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000397> <http://geneontology.org/lego/evidence-with> "SGD:S000000503"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://purl.obolibrary.org/obo/ECO_0000250> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:2549370"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000398> <http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000307> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "GO_REF:0000015"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000399> <http://geneontology.org/lego/hint/layout/x> "1256.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "381.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/61452e3d00000323/61452e3d00000400> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/61452e3d00000323/61452e3d00000401> ;
+	<http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/61452e3d00000323/61452e3d00000402> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003700> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2024-06-14"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000400> <http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000029659> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000401> <http://geneontology.org/lego/hint/layout/x> "1256.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0006355> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2024-06-14"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000402> <http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005634> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000403> <http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://purl.obolibrary.org/obo/ECO_0000315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:10447589"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000404> <http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://purl.obolibrary.org/obo/ECO_0000315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:10447589"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000405> <http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:10447589"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000406> <http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:10447589"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000407> <http://geneontology.org/lego/hint/layout/x> "862.5"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "381.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/61452e3d00000323/61452e3d00000408> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/61452e3d00000323/61452e3d00000409> ;
+	<http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/61452e3d00000323/61452e3d00000410> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003700> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2024-06-14"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000408> <http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000501> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000409> <http://geneontology.org/lego/hint/layout/x> "862.5"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0006355> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2024-06-14"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000410> <http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005634> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000411> <http://geneontology.org/lego/evidence-with> "SGD:S000029659"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://purl.obolibrary.org/obo/ECO_0000250> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:10447589"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000412> <http://geneontology.org/lego/evidence-with> "SGD:S000029659"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://purl.obolibrary.org/obo/ECO_0000250> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:10447589"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000413> <http://geneontology.org/lego/evidence-with> "SGD:S000029659"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://purl.obolibrary.org/obo/ECO_0000250> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:10447589"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000414> <http://geneontology.org/lego/hint/layout/x> "2043.75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "687.5"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/61452e3d00000323/61452e3d00000415> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/61452e3d00000323/61452e3d00000416> ;
+	<http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/61452e3d00000323/61452e3d00000418> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003700> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2024-06-14"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000415> <http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000029657> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000416> <http://geneontology.org/lego/hint/layout/x> "468.75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "381.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/61452e3d00000323/61452e3d00000417> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0006355> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2024-06-14"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000417> <http://geneontology.org/lego/hint/layout/x> "468.75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0000025> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2024-06-14"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000418> <http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005634> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000419> <http://geneontology.org/lego/evidence-with> "SGD:S000029659"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://purl.obolibrary.org/obo/ECO_0000250> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:2549370"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000420> <http://geneontology.org/lego/evidence-with> "SGD:S000029659"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://purl.obolibrary.org/obo/ECO_0000250> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:2549370"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000421> <http://geneontology.org/lego/evidence-with> "SGD:S000029659"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://purl.obolibrary.org/obo/ECO_0000250> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:2549370"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000422> <http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://purl.obolibrary.org/obo/ECO_0000315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:20562106"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000423> <http://geneontology.org/lego/hint/layout/x> "1650"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "687.5"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/61452e3d00000323/61452e3d00000424> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/61452e3d00000323/61452e3d00000425> ;
+	<http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/61452e3d00000323/61452e3d00000427> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003700> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2024-06-14"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000424> <http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000029688> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000425> <http://geneontology.org/lego/hint/layout/x> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "381.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/61452e3d00000323/61452e3d00000426> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0006355> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2024-06-14"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000426> <http://geneontology.org/lego/hint/layout/x> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0000025> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2024-06-14"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000427> <http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005634> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000428> <http://geneontology.org/lego/evidence-with> "SGD:S000029659"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://purl.obolibrary.org/obo/ECO_0000250> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:10447589"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000429> <http://geneontology.org/lego/evidence-with> "SGD:S000029659"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://purl.obolibrary.org/obo/ECO_0000250> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:10447589"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000430> <http://geneontology.org/lego/evidence-with> "SGD:S000029659"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://purl.obolibrary.org/obo/ECO_0000250> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:10447589"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/61452e3d00000323/61452e3d00000431> <http://geneontology.org/lego/evidence-with> "SGD:S000029659"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://purl.obolibrary.org/obo/ECO_0000250> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:2549370"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://purl.obolibrary.org/obo/GO_0032450> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_1904981> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.org/dc/elements/1.1/title> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.org/dc/elements/1.1/contributor> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.org/dc/elements/1.1/date> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.org/dc/elements/1.1/source> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+_:t2573176 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/61452e3d00000323/61452e3d00000334> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000050> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/61452e3d00000323/61452e3d00000329> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/61452e3d00000323/61452e3d00000331> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+_:t2573177 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/61452e3d00000323/61452e3d00000382> , <http://model.geneontology.org/61452e3d00000323/61452e3d00000383> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000050> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/61452e3d00000323/61452e3d00000377> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/61452e3d00000323/61452e3d00000379> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+_:t2573178 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/61452e3d00000323/61452e3d00000384> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000066> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/61452e3d00000323/61452e3d00000377> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/61452e3d00000323/61452e3d00000380> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+_:t2573179 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/61452e3d00000323/61452e3d00000381> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/61452e3d00000323/61452e3d00000377> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/61452e3d00000323/61452e3d00000378> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+_:t2573180 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/61452e3d00000323/61452e3d00000390> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000050> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/61452e3d00000323/61452e3d00000385> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/61452e3d00000323/61452e3d00000387> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+_:t2573181 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/61452e3d00000323/61452e3d00000391> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000066> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/61452e3d00000323/61452e3d00000385> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/61452e3d00000323/61452e3d00000388> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+_:t2573182 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/61452e3d00000323/61452e3d00000389> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/61452e3d00000323/61452e3d00000385> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/61452e3d00000323/61452e3d00000386> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+_:t2573183 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/61452e3d00000323/61452e3d00000397> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000050> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/61452e3d00000323/61452e3d00000392> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/61452e3d00000323/61452e3d00000394> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+_:t2573184 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/61452e3d00000323/61452e3d00000398> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000066> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/61452e3d00000323/61452e3d00000392> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/61452e3d00000323/61452e3d00000395> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+_:t2573185 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/61452e3d00000323/61452e3d00000396> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/61452e3d00000323/61452e3d00000392> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/61452e3d00000323/61452e3d00000393> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+_:t2573186 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/61452e3d00000323/61452e3d00000404> , <http://model.geneontology.org/61452e3d00000323/61452e3d00000405> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000050> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/61452e3d00000323/61452e3d00000399> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/61452e3d00000323/61452e3d00000401> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+_:t2573187 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/61452e3d00000323/61452e3d00000335> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000066> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/61452e3d00000323/61452e3d00000329> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/61452e3d00000323/61452e3d00000332> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+_:t2573188 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/61452e3d00000323/61452e3d00000406> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000066> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/61452e3d00000323/61452e3d00000399> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/61452e3d00000323/61452e3d00000402> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+_:t2573189 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/61452e3d00000323/61452e3d00000403> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/61452e3d00000323/61452e3d00000399> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/61452e3d00000323/61452e3d00000400> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+_:t2573190 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/61452e3d00000323/61452e3d00000412> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000050> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/61452e3d00000323/61452e3d00000407> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/61452e3d00000323/61452e3d00000409> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+_:t2573191 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/61452e3d00000323/61452e3d00000413> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000066> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/61452e3d00000323/61452e3d00000407> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/61452e3d00000323/61452e3d00000410> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+_:t2573192 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/61452e3d00000323/61452e3d00000411> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/61452e3d00000323/61452e3d00000407> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/61452e3d00000323/61452e3d00000408> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+_:t2573193 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/61452e3d00000323/61452e3d00000420> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000050> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/61452e3d00000323/61452e3d00000414> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/61452e3d00000323/61452e3d00000416> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+_:t2573194 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/61452e3d00000323/61452e3d00000421> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000066> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/61452e3d00000323/61452e3d00000414> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/61452e3d00000323/61452e3d00000418> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+_:t2573195 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/61452e3d00000323/61452e3d00000419> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/61452e3d00000323/61452e3d00000414> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/61452e3d00000323/61452e3d00000415> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+_:t2573196 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/61452e3d00000323/61452e3d00000422> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000050> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/61452e3d00000323/61452e3d00000416> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/61452e3d00000323/61452e3d00000417> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+_:t2573197 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/61452e3d00000323/61452e3d00000429> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000050> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/61452e3d00000323/61452e3d00000423> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/61452e3d00000323/61452e3d00000425> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+_:t2573198 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/61452e3d00000323/61452e3d00000333> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/61452e3d00000323/61452e3d00000329> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/61452e3d00000323/61452e3d00000330> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+_:t2573199 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/61452e3d00000323/61452e3d00000430> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000066> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/61452e3d00000323/61452e3d00000423> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/61452e3d00000323/61452e3d00000427> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+_:t2573200 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/61452e3d00000323/61452e3d00000428> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/61452e3d00000323/61452e3d00000423> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/61452e3d00000323/61452e3d00000424> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+_:t2573201 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/61452e3d00000323/61452e3d00000431> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000050> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/61452e3d00000323/61452e3d00000425> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/61452e3d00000323/61452e3d00000426> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+_:t2573202 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/61452e3d00000323/61452e3d00000352> , <http://model.geneontology.org/61452e3d00000323/61452e3d00000353> , <http://model.geneontology.org/61452e3d00000323/61452e3d00000354> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000050> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/61452e3d00000323/61452e3d00000347> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/61452e3d00000323/61452e3d00000349> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+_:t2573203 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/61452e3d00000323/61452e3d00000355> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000066> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/61452e3d00000323/61452e3d00000347> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/61452e3d00000323/61452e3d00000350> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+_:t2573204 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/61452e3d00000323/61452e3d00000351> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/61452e3d00000323/61452e3d00000347> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/61452e3d00000323/61452e3d00000348> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+_:t2573205 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/61452e3d00000323/61452e3d00000363> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000050> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/61452e3d00000323/61452e3d00000358> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/61452e3d00000323/61452e3d00000360> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+_:t2573206 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/61452e3d00000323/61452e3d00000364> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000066> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/61452e3d00000323/61452e3d00000358> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/61452e3d00000323/61452e3d00000361> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+_:t2573207 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/61452e3d00000323/61452e3d00000362> ;
+	<http://purl.org/pav/providedBy> "http://www.yeastgenome.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/61452e3d00000323/61452e3d00000358> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/61452e3d00000323/61452e3d00000359> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5472-917X"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-09-21"^^<http://www.w3.org/2001/XMLSchema#string> .

--- a/resources/test/MGI_MGI_1100089.ttl
+++ b/resources/test/MGI_MGI_1100089.ttl
@@ -1,0 +1,2771 @@
+
+<http://model.geneontology.org/MGI_MGI_1100089> a <http://www.w3.org/2002/07/owl#Ontology> .
+
+<http://geneontology.org/lego/evidence> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://geneontology.org/lego/evidence-with> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://geneontology.org/lego/hint/layout/x> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://geneontology.org/lego/hint/layout/y> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://geneontology.org/lego/modelstate> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/ECO_0000315> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0003674> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/RO_0002333> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.obolibrary.org/obo/RO_0002418> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.org/pav/providedBy> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<https://w3id.org/biolink/vocab/in_taxon> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/BFO_0000050> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.obolibrary.org/obo/BFO_0000066> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.obolibrary.org/obo/EMAPA_16846> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/RO_0002296> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.org/dc/terms/created> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.org/dc/terms/dateAccepted> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/ECO_0000314> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/ECO_0000353> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0005515> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/RO_0002233> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.obolibrary.org/obo/ECO_0000270> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/ECO_0000304> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/ECO_0000316> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/RO_0002213> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.obolibrary.org/obo/GO_0010628> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/CL_0000066> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0042802> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0007249> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0043123> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/RO_0002315> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.obolibrary.org/obo/RO_0012003> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.obolibrary.org/obo/GO_0048018> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_1990830> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0001503> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0007254> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0051897> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0043491> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0033209> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0046330> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/CL_0000092> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0009887> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0060348> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/EMAPA_17760> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0036035> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_2001206> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0033598> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0055074> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0045453> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0030316> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/EMAPA_36566> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/CL_0002476> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0060749> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0045670> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0048535> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/mgi/MGI:1100089> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/mgi/MGI:95574> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/MGI_MGI_1100089> <http://geneontology.org/lego/modelstate> "production"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#versionIRI> <http://model.geneontology.org/MGI_MGI_1100089> ;
+	<https://w3id.org/biolink/vocab/in_taxon> <http://purl.obolibrary.org/obo/NCBITaxon_10090> ;
+	<http://purl.org/dc/terms/created> "2000-07-06" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Ontology> ;
+	<http://purl.org/dc/elements/1.1/title> "Tnfsf11 (MGI:MGI:1100089)" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" , "https://orcid.org/0000-0003-2689-5511" , "https://orcid.org/0000-0003-3394-9805" , "https://orcid.org/0000-0001-5501-853X" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> , "GOC:tc" ;
+	<http://purl.org/dc/elements/1.1/date> "2023-12-05"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/00ff48b9-1f29-414a-a9fe-30fbf7f0b3f2> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2018-01-31" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1100089> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-01-31" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/02dc2866-9e33-4e1f-a5bc-53f5192066dc> <http://geneontology.org/lego/hint/layout/x> "8737.5"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/MGI_MGI_1100089/fe66d09a-03f9-4797-997f-bf5cfdb7f616> ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0043491> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/03552651-4591-4f6e-87c6-c3d94b89c2a9> <http://geneontology.org/lego/evidence-with> "MGI:MGI:2158925" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2013-01-09" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000316> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2013-01-09" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:21982707" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/0458fa3d-573d-4e5b-8b78-258baa989cad> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2019-01-24" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "target Tcirg1;MGI:1350931" , "The murine microglial cell line N9 ; RANKL stimulated increased the relative expression of subunit a3" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2019-01-24" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:19715671" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/06f0ebb7-e3cc-4f91-854e-bff4a162dd91> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2015-10-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2015-10-28" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:18269914" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/0899406b-8e55-4502-ace5-77606e4737c3> <http://geneontology.org/lego/evidence-with> "MGI:MGI:5614816" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2018-01-31" ;
+	a <http://purl.obolibrary.org/obo/ECO_0000315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-01-31" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:26234751" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/093519c2-8bb6-4414-9b4b-bf79d479e2d1> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2018-02-22" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1100089> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-02-22" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/0949b10b-153f-4204-878e-6ab89d10fecb> <http://geneontology.org/lego/hint/layout/x> "8343.75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/MGI_MGI_1100089/8a9b9a1d-c14e-4f83-a3a9-95c1f71e5363> ;
+	<http://purl.org/dc/terms/created> "2012-06-11" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0007254> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/0ad06254-0f74-4162-9360-30f2522d278e> <http://geneontology.org/lego/hint/layout/x> "862.5"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1100089/536cbcb7-b338-4e95-a290-88449707d3c2> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2003-10-28" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.obolibrary.org/obo/RO_0002233> <http://model.geneontology.org/MGI_MGI_1100089/b0dc50ca-fb75-4738-9bdb-5b252fd1f463> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0042802> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" , "https://orcid.org/0000-0003-2689-5511" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/0af03b2c-a62f-4743-971d-4f9af273cf15> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2019-01-24" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "We found that the amount of a3 in the cytoskeletal fraction increased from 32% to 81% (" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2019-01-24" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:19715671" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/0bda47fe-9143-4225-bd2f-10c3c95aa477> <http://geneontology.org/lego/evidence-with> "PR:O35235" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2003-10-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000353> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "forms trimer (as determined by X-ray structure" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" , "https://orcid.org/0000-0003-2689-5511" ;
+	<http://purl.org/dc/elements/1.1/date> "2019-07-10" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:11859102" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/0c0222c9-e115-41ec-a90f-24374cbd3a30> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2013-03-21" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2013-03-21" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:22451653" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/0c026612-109f-4a92-99e8-54f27613dc0f> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2005-12-23" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "cell type osteoclast ; CL:0000092 primary_cell_line ; CL:0000001" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-12-23" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:15724149" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/0cebddcc-7747-47f3-b390-ad238a531adf> <http://geneontology.org/lego/hint/layout/x> "665.625"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "381.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1100089/922b341f-766c-41de-8b24-efa9e0d195dc> ;
+	<http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_1100089/91ece7be-7ffa-40f4-86be-074e063ce048> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2013-01-09" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/0de20908-1afe-42fb-9912-d4e0bfc6b063> <http://geneontology.org/lego/hint/layout/x> "8146.875"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "381.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2012-06-11" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.obolibrary.org/obo/RO_0002213> <http://model.geneontology.org/MGI_MGI_1100089/0949b10b-153f-4204-878e-6ab89d10fecb> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0046330> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/0f34029b-72e0-41bd-a157-22d3e3327153> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "anatomy mammary gland epithelium ; MA:0000792" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2009-07-07" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:19298785" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/0fa618e9-69a0-4770-9761-8870f11773db> <http://geneontology.org/lego/evidence-with> "MGI:MGI:1859962" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2000-07-06" ;
+	a <http://purl.obolibrary.org/obo/ECO_0000315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "GOC:tc" ;
+	<http://purl.org/dc/elements/1.1/date> "2000-07-06" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:9950424" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/10323e33-78d3-4bfb-9c8f-5e93e3283cf6> <http://geneontology.org/lego/evidence-with> "MGI:MGI:1859962" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2000-07-06" ;
+	a <http://purl.obolibrary.org/obo/ECO_0000315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "GOC:tc" ;
+	<http://purl.org/dc/elements/1.1/date> "2000-07-06" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:9950424" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/115479f4-8c64-438a-90cf-f9908f9a6513> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2018-03-08" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-03-08" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:21841309" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/11929829-8f47-4966-bf3e-c3639b59086e> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2005-12-23" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "cell type osteoclast ; CL:0000092 primary_cell_line ; CL:0000001" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-12-23" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:15724149" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/11c4f543-3f2d-4e19-ba53-6a2502d8740f> <http://geneontology.org/lego/hint/layout/x> "6965.625"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "381.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1100089/3151c07b-4947-461a-8d43-9683fed21b96> ;
+	<http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_1100089/2e4bf66c-dc08-4cf2-b6e6-b57ffdbede23> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2019-01-24" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/1237bf34-6cac-4688-91ab-3da99857003d> <http://geneontology.org/lego/evidence-with> "MGI:MGI:99484" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2005-03-17" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000316> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "anatomy TS26\\ liver; EMAP:12229" , "cell type osteoclast ; CL:0000092 primary_cell_line ; CL:0000001" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-03-17" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:15485831" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/12c599a6-b1ae-4864-9173-e7b825a5a95e> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/EMAPA_17760> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2009-07-07" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/14d813d6-6505-4bb4-a7e3-e5ea0d4e7ef4> <http://geneontology.org/lego/hint/layout/x> "5784.375"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "687.5"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1100089/a072971e-f37b-4d6b-89d0-6ed11817c61c> ;
+	<http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_1100089/0de20908-1afe-42fb-9912-d4e0bfc6b063> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2012-06-11" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/154be8f3-3240-40b2-865f-81c0bfcf5a9c> <http://geneontology.org/lego/evidence-with> "PR:O35235" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2003-10-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000353> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "binds itself (trimer)" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" , "https://orcid.org/0000-0003-2689-5511" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-03-17" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:11859102" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/1806437c-37fe-40ad-b132-72ff76b48392> <http://geneontology.org/lego/evidence-with> "MGI:MGI:1859962" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	a <http://purl.obolibrary.org/obo/ECO_0000315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "anatomy mammary gland alveolus ; MA:0002760" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2010-10-28" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:11051546" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/188e0f9b-862a-4615-aa32-1f8732f0d4c3> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2003-09-12" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1100089> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2003-09-12" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/18ebc54a-5cb5-4232-9b66-ae77098e6808> <http://geneontology.org/lego/evidence-with> "MGI:MGI:2158925" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2013-01-09" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000316> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2013-01-09" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:21982707" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/1a38828c-3d8c-4c93-b949-696551594a01> <http://geneontology.org/lego/hint/layout/x> "7950"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2019-01-24" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_1904616> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/1a8cb1c0-7aef-430c-9c59-958bc8f4f974> <http://geneontology.org/lego/evidence-with> "MGI:MGI:5614816" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2018-01-31" ;
+	a <http://purl.obolibrary.org/obo/ECO_0000315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-01-31" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:26234751" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/1d1c5018-3a8e-45da-afe2-83b5137ee791> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2017-06-14" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1100089> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2017-06-14" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/1d74bc80-a582-4992-8545-edd5a1d48a1b> <http://geneontology.org/lego/hint/layout/x> "7556.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2003-09-12" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0045670> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" , "https://orcid.org/0000-0003-3394-9805" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/2036c49b-448b-41f5-a113-5eadc3596f48> <http://geneontology.org/lego/hint/layout/x> "1453.125"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "381.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1100089/8d5c5f54-a9c0-4d30-8736-38f350e943dc> ;
+	<http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_1100089/9ccd6d81-ef1c-4a4c-b3b0-3d2e3f2c482f> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2018-01-31" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/23cd23c1-33a3-4fc2-a380-131cc6690ec0> <http://geneontology.org/lego/hint/layout/x> "6768.75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2015-10-21" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0033209> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-12-05"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/25a94ce7-5d06-4275-a9e8-12ce2e05ac32> <http://geneontology.org/lego/evidence-with> "MGI:MGI:102469" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2013-01-09" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000316> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2013-01-09" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:21982707" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/25f475f8-9995-45ed-8dd8-1e2f780c3d58> <http://geneontology.org/lego/evidence-with> "MGI:MGI:1859962" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	a <http://purl.obolibrary.org/obo/ECO_0000315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "cell type epithelial cell ; CL:0000066" , "anatomy mammary gland epithelium ; MA:0000792" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2009-07-07" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:11051546" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/29335aba-eda4-45ba-ac08-612cbd62f2d0> <http://geneontology.org/lego/hint/layout/x> "8540.625"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "381.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002296> <http://model.geneontology.org/MGI_MGI_1100089/fc51def0-a97d-4625-b501-bbd826cd264a> ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0060749> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/2bc03819-31d9-46f7-87df-b6b816140c6d> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1100089> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2010-10-28" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/2e4bf66c-dc08-4cf2-b6e6-b57ffdbede23> <http://geneontology.org/lego/hint/layout/x> "7162.5"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2019-01-24" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0010628> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/2e58dc0f-f2ce-40a9-8ed4-e715db160346> <http://geneontology.org/lego/hint/layout/x> "3421.875"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "381.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1100089/1d1c5018-3a8e-45da-afe2-83b5137ee791> ;
+	<http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_1100089/53718c9c-32b7-488f-b0a8-e3d06c5adb40> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2017-06-14" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/3151c07b-4947-461a-8d43-9683fed21b96> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2019-01-24" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1100089> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2019-01-24" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/32cd7c73-31ba-439d-8d4c-2657daec68d7> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2015-03-19" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2015-03-19" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:24190884" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/34423773-244e-48c5-ae4d-bac5563785aa> <http://geneontology.org/lego/hint/layout/x> "10219.633331298828"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "290.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1100089/4baaee02-2e20-4772-a7b8-66bdbffbf6e8> ;
+	<http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_1100089/e2a15cc9-72b8-45cb-851e-b45141a33e78> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2000-08-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-2689-5511" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> , "GOC:tc" ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/34d3f2f3-dd82-4932-a528-4873441aaa9f> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2018-02-22" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-02-22" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:17442941" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/36a54bd5-c49e-4bd2-b32f-0f3b9ff5d2b7> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2018-02-22" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-02-22" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:17442941" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/36ae595b-adac-4de3-a4dc-66297e38cad3> <http://geneontology.org/lego/hint/layout/x> "5981.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2003-09-12" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0045453> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/372ff363-e619-4aa1-b877-7ca3bdfe64a7> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2000-08-07" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000304> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "lymph gland development obsoleted" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-2689-5511" , "GOC:tc" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-06-13" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:10687308" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/380a5f4b-0329-46ae-87d7-17a1bfae7e1d> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2005-03-17" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1100089> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-03-17" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/382b0d09-5b99-40a5-a1eb-30df545e024b> <http://geneontology.org/lego/hint/layout/x> "10110.63330078125"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "772.5"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1100089/3cbb43ea-417c-4fb6-9c2a-48c4b7469c04> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/MGI_MGI_1100089/3d33b4d3-16e1-4eb6-a9c8-55d237a4763f> ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0048018> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/3a3838b0-4d69-4958-9f06-ca1cac5844ef> <http://geneontology.org/lego/hint/layout/x> "5390.625"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "687.5"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2005-12-23" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.obolibrary.org/obo/RO_0002213> <http://model.geneontology.org/MGI_MGI_1100089/85b039b9-df79-4b01-bca4-d3cfc681a3be> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0045672> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/3bad60ec-4a12-4f38-b1e6-2780c266fa60> <http://geneontology.org/lego/hint/layout/x> "6375"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2005-05-06" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0045672> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" , "https://orcid.org/0000-0002-9796-7693" , "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/3c3d184d-ec65-4e0f-9136-eda837b3dbc5> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "anatomy mammary gland epithelium ; MA:0000792" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2009-07-07" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:19298785" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/3cbb43ea-417c-4fb6-9c2a-48c4b7469c04> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1100089> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2009-07-07" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/3d33b4d3-16e1-4eb6-a9c8-55d237a4763f> <http://geneontology.org/lego/hint/layout/x> "10491.38330078125"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "468.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.obolibrary.org/obo/RO_0002213> <http://model.geneontology.org/MGI_MGI_1100089/d7b70a30-f6af-461c-b1c3-4b86ca3d7bf7> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0043123> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/42548bce-2619-4a37-9b74-c0563f3ce7f6> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1100089> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2009-07-07" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/435df2bc-2186-4a4a-893f-ef9180a0c084> <http://geneontology.org/lego/hint/layout/x> "2240.625"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "381.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1100089/00ff48b9-1f29-414a-a9fe-30fbf7f0b3f2> ;
+	<http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_1100089/7a4e1c56-8d5b-4bda-ba62-93d3ac8e1923> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2018-01-31" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/436eeaa0-d705-4468-b374-8b8476998c70> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2003-10-28" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/PR_O35235> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" , "https://orcid.org/0000-0003-2689-5511" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-03-17" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/44d57ec2-7107-4066-9535-90b4a7a83d37> <http://geneontology.org/lego/hint/layout/x> "4800"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CL_0000066> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/460c6261-9afa-4ffd-82c1-4a605f5cbb45> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2005-05-06" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-05-06" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:15657444" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/479e4f7e-bd4d-40f8-b587-dcf4bf44a751> <http://geneontology.org/lego/evidence-with> "MGI:MGI:1859962" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	a <http://purl.obolibrary.org/obo/ECO_0000315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "cell type epithelial cell ; CL:0000066" , "anatomy mammary gland epithelium ; MA:0000792" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2009-07-07" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:11051546" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/47e18425-8745-4005-a8f2-fe7cbc9eb369> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2005-03-17" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/EMAPA_16846> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-03-17" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/49b44f0e-6e30-4905-a871-6cff1cac5fd5> <http://geneontology.org/lego/hint/layout/x> "468.75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1100089/afc04389-0b93-4c84-9367-66a4129484df> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2003-10-28" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.obolibrary.org/obo/RO_0002233> <http://model.geneontology.org/MGI_MGI_1100089/436eeaa0-d705-4468-b374-8b8476998c70> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005515> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-2689-5511" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/4aac0fab-0e4b-4972-909f-2d982cb1844e> <http://geneontology.org/lego/hint/layout/x> "5587.5"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2014-03-27" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_2001206> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" , "https://orcid.org/0000-0003-3394-9805" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/4baaee02-2e20-4772-a7b8-66bdbffbf6e8> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2000-08-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1100089> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-2689-5511" , "GOC:tc" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-06-13" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/4c632c01-9ea4-4d7a-a075-42d64872620f> <http://geneontology.org/lego/evidence-with> "MGI:MGI:1859962" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	a <http://purl.obolibrary.org/obo/ECO_0000315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "cell type epithelial cell ; CL:0000066" , "anatomy mammary gland epithelium ; MA:0000792" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2009-07-07" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:11051546" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/4d3d8f73-bb9d-4436-bbc1-2e51e432e42a> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2003-09-12" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2003-09-12" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:12490655" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/4d4ece49-7ca5-48d9-a2e8-ddab30db87fb> <http://geneontology.org/lego/evidence-with> "MGI:MGI:1859962" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	a <http://purl.obolibrary.org/obo/ECO_0000315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "cell type epithelial cell ; CL:0000066" , "anatomy mammary gland epithelium ; MA:0000792" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2009-07-07" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:11051546" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/4ddc75d5-48d4-4520-96fb-c8b4ce99cc5f> <http://geneontology.org/lego/hint/layout/x> "5193.75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2005-12-23" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CL_0000092> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/4f8a7b22-eaab-4c0a-a150-de435ae25455> <http://geneontology.org/lego/evidence-with> "MGI:MGI:109520" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2012-06-11" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000316> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "cell type primary cell line cell ; CL:0000001 osteoclast ; CL:0000092" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2012-06-11" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:22073305" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/52d9419f-ff84-4bdd-8ea0-eb550b1b82e2> <http://geneontology.org/lego/evidence-with> "MGI:MGI:2158925" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2013-01-09" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000316> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "cell type permanent cell line cell ; CLO:0000019 RAW 264.7 ; ATCC:TIB-71" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2013-01-09" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:21982707" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/52fb87fb-70e5-4e9f-8aa4-508307c8918b> <http://geneontology.org/lego/hint/layout/x> "3815.625"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "381.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1100089/daa0ff62-bf1a-45f2-aa40-c757a7ae4158> ;
+	<http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_1100089/5f35f4a9-05fd-4c37-92b2-a9e38b8d3bef> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2000-07-06" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> , "GOC:tc" ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/536cbcb7-b338-4e95-a290-88449707d3c2> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2003-10-28" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1100089> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" , "https://orcid.org/0000-0003-2689-5511" ;
+	<http://purl.org/dc/elements/1.1/date> "2019-07-10" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/53718c9c-32b7-488f-b0a8-e3d06c5adb40> <http://geneontology.org/lego/hint/layout/x> "3618.75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2017-06-14" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_1990830> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/54459d87-38a3-41a2-93c5-1aafb89d62b2> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2018-02-22" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-02-22" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:17442941" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/5462f6bb-b633-4a6a-ba73-d8328de17585> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2015-10-21" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2015-10-21" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:22437732" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/54ab1568-75a4-4dfc-8130-198487e64b6e> <http://geneontology.org/lego/evidence-with> "MGI:MGI:1859962" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	a <http://purl.obolibrary.org/obo/ECO_0000315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "cell type epithelial cell ; CL:0000066" , "anatomy mammary gland alveolus ; MA:0002760" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2009-07-07" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:11051546" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/54dbca03-f4e9-4457-b2fd-2c8f2d92e9c2> <http://geneontology.org/lego/hint/layout/x> "1059.375"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "381.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/MGI_MGI_1100089/47e18425-8745-4005-a8f2-fe7cbc9eb369> ;
+	<http://purl.org/dc/terms/created> "2005-03-17" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.obolibrary.org/obo/RO_0002315> <http://model.geneontology.org/MGI_MGI_1100089/9d89ac91-9ddf-4894-9090-908ac596465d> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0030316> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/552aa0ac-1f95-4aa8-8ea8-7977d1ac0b56> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2005-12-23" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1100089> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2007-02-12" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/5701d88b-e3c2-418d-bb80-c0e42f25fe39> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2018-02-22" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:95574> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-02-22" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/57336943-4437-4c32-a940-9c88ff0ad890> <http://geneontology.org/lego/hint/layout/x> "3225"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2018-02-22" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.obolibrary.org/obo/RO_0002233> <http://model.geneontology.org/MGI_MGI_1100089/5701d88b-e3c2-418d-bb80-c0e42f25fe39> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0010628> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/5754568e-bcf6-47ec-bd81-29ca39324917> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2005-12-23" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "cell type osteoclast ; CL:0000092 primary_cell_line ; CL:0000001" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-12-23" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:15724149" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/57d511d7-a557-4735-9117-861dc720ab79> <http://geneontology.org/lego/evidence-with> "MGI:MGI:1859962" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	a <http://purl.obolibrary.org/obo/ECO_0000315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "cell type epithelial cell ; CL:0000066" , "anatomy mammary gland epithelium ; MA:0000792" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2009-07-07" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:11051546" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/58d0f505-7944-46e0-a998-22274b434b36> <http://geneontology.org/lego/hint/layout/x> "4996.875"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "687.5"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1100089/42548bce-2619-4a37-9b74-c0563f3ce7f6> ;
+	<http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_1100089/8b23580a-252b-463b-bc29-4f606bdc66c1> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/5b90a611-fb9d-48c2-a35d-1ea16a5c0dcc> <http://geneontology.org/lego/hint/layout/x> "4406.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2015-03-19" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0038001> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/5f35f4a9-05fd-4c37-92b2-a9e38b8d3bef> <http://geneontology.org/lego/hint/layout/x> "4012.5"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2000-07-06" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0001503> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> , "GOC:tc" ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/60fcf2b3-8aa2-47e8-81a9-203134ace208> <http://geneontology.org/lego/hint/layout/x> "2831.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2004-04-30" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0030316> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/61a1eb2b-1233-48cf-ab7b-4ea8aa4cff74> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2005-05-06" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-05-06" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:15657444" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/63f9aa13-dfd7-4267-a798-aa5e93d6cb81> <http://geneontology.org/lego/evidence-with> "MGI:MGI:104798" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2005-03-17" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000316> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "anatomy TS26\\ liver; EMAP:12229" , "cell type osteoclast ; CL:0000092 primary_cell_line ; CL:0000001" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-03-17" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:15485831" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/65039e8700001566> <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:19298785"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/65975a29-2858-4db8-8140-c4315f69d3b2> <http://geneontology.org/lego/evidence-with> "MGI:MGI:1859962" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	a <http://purl.obolibrary.org/obo/ECO_0000315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "cell type epithelial cell ; CL:0000066" , "anatomy mammary gland alveolus ; MA:0002760" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2009-07-07" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:11051546" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/68247adb-1be4-4b33-a992-ae234f9f139d> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2018-02-22" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CL_0002476> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-02-22" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/6922fbbc-e14b-49a4-a3fc-96a26b3614ae> <http://geneontology.org/lego/evidence-with> "MGI:MGI:1339753" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2015-10-30" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000316> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "anatomy bone marrow ; MA:0000134" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2015-10-30" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:21048959" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/6959e026-b579-4255-96d4-02ec89af1981> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2018-02-22" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-02-22" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:17442941" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/6df7df7f-ebca-4bab-8bfd-e2f5ec9634a0> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2015-10-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2015-10-28" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:18269914" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/6ef8de1b-1329-446a-a882-5cd5146328cd> <http://geneontology.org/lego/evidence-with> "MGI:MGI:109520" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2012-06-11" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000316> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "cell type primary cell line cell ; CL:0000001 osteoclast ; CL:0000092" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2012-06-11" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:22073305" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/6f54e095-d1a7-410a-a5a9-5c2e382e3c93> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2018-03-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1100089> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-03-08" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/6fafa7c7-b2f4-4efd-ba2b-2bc3a7a8d121> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2000-07-06" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1100089> ;
+	<http://purl.org/dc/elements/1.1/contributor> "GOC:tc" ;
+	<http://purl.org/dc/elements/1.1/date> "2000-07-06" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/70953549-c4ea-4cab-b3a1-30b5f2443967> <http://geneontology.org/lego/hint/layout/x> "9328.125"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "381.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.obolibrary.org/obo/RO_0002213> <http://model.geneontology.org/MGI_MGI_1100089/02dc2866-9e33-4e1f-a5bc-53f5192066dc> , <http://model.geneontology.org/MGI_MGI_1100089/af610518-2fc7-4a3a-b70e-e366a55a1c03> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0051897> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/71572243-1978-46a7-acec-40e21e2022e9> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2019-01-24" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "target Tcirg1;MGI:1350931" , "The murine microglial cell line N9 ; RANKL stimulated increased the relative expression of subunit a3" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2019-01-24" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:19715671" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/7179f5b4-ea4b-4693-9499-213516e26c94> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/EMAPA_36566> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2009-07-07" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/71c1b1f0-9b81-4127-aea9-4a5d420ab5f1> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2018-02-22" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-02-22" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:17442941" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/74fe2098-70a9-4715-9ef5-54965d35a170> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1100089> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2009-07-07" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/7a4e1c56-8d5b-4bda-ba62-93d3ac8e1923> <http://geneontology.org/lego/hint/layout/x> "2437.5"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2018-01-31" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0060348> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/7c03dfd6-b031-4709-a8df-3176d6dda57b> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2014-03-27" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2014-03-27" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:23980096" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/7d673a97-cb4e-4f95-bc56-70242f3eed53> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2013-08-27" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2013-08-27" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:23395171" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/7e696abb-bff9-40f5-a04e-275ec696aebc> <http://geneontology.org/lego/evidence-with> "MGI:MGI:1339753" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2007-02-12" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000316> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "cell type primary cell line cell ; CL:0000001 osteoclast ; CL:0000092" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2007-02-12" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:17053831" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/80baa21f-d09c-4c17-933a-04c7817687e4> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2017-06-14" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000270> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "mouse embryonic stem cells; expression decreased upon the induction of differentiation" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2017-06-14" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:20439489" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/80ffa85f-06fc-4170-8271-48492c1b8871> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2018-02-22" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-02-22" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:17442941" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/813644a5-1c76-40f8-967a-ab7044abb336> <http://geneontology.org/lego/evidence-with> "PR:O35235" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2003-10-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000353> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "forms trimer (as determined by X-ray structure" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" , "https://orcid.org/0000-0003-2689-5511" ;
+	<http://purl.org/dc/elements/1.1/date> "2019-07-10" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:11859102" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/82a20020-05ff-4458-adf9-7e9ffb7aaa5d> <http://geneontology.org/lego/hint/layout/x> "2043.75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2013-03-21" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0002158> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/82f0b431-4d2f-44d5-bbe6-53ee7a70c43c> <http://geneontology.org/lego/hint/layout/x> "6178.125"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "381.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1100089/c0beb774-354a-4781-b5b2-2cf27483011a> ;
+	<http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_1100089/3bad60ec-4a12-4f38-b1e6-2780c266fa60> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2005-05-06" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" , "https://orcid.org/0000-0003-3394-9805" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/8555e920-3990-4442-bde7-fb5bb8b4f9cd> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2004-04-30" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2004-04-30" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:14662855" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/85b039b9-df79-4b01-bca4-d3cfc681a3be> <http://geneontology.org/lego/hint/layout/x> "4996.875"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "381.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2005-12-23" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.obolibrary.org/obo/RO_0002315> <http://model.geneontology.org/MGI_MGI_1100089/4ddc75d5-48d4-4520-96fb-c8b4ce99cc5f> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0030316> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/85dec380-e8ba-4bd2-857d-40ca62e5b1cf> <http://geneontology.org/lego/evidence-with> "MGI:MGI:109520" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2012-06-11" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000316> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "cell type primary cell line cell ; CL:0000001 osteoclast ; CL:0000092" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2012-06-11" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:22073305" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/865e84da-740f-4a57-8d30-2be6f695f202> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2003-09-12" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2003-09-12" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:12490655" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/8743ce71-9ea0-4d8a-b04c-f33146caeb32> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2013-08-27" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2013-08-27" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:23395171" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/885748da-acf1-4504-8dda-2522e1ca26bb> <http://geneontology.org/lego/evidence-with> "MGI:MGI:104798" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2005-03-17" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000316> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "anatomy TS26\\ liver; EMAP:12229" , "cell type osteoclast ; CL:0000092 primary_cell_line ; CL:0000001" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-03-17" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:15485831" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/8a9b9a1d-c14e-4f83-a3a9-95c1f71e5363> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2012-06-11" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CL_0000092> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2012-06-11" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/8b23580a-252b-463b-bc29-4f606bdc66c1> <http://geneontology.org/lego/hint/layout/x> "4603.125"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "381.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/MGI_MGI_1100089/7179f5b4-ea4b-4693-9499-213516e26c94> ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.obolibrary.org/obo/RO_0012003> <http://model.geneontology.org/MGI_MGI_1100089/44d57ec2-7107-4066-9535-90b4a7a83d37> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0033598> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/8b39660d-6dab-49bd-93de-ba3b2f4b3ab6> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2015-03-19" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2015-03-19" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:24190884" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/8c729218-bb3b-454e-82b6-ffd3261830b5> <http://geneontology.org/lego/hint/layout/x> "5784.375"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "381.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1100089/188e0f9b-862a-4615-aa32-1f8732f0d4c3> ;
+	<http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_1100089/36ae595b-adac-4de3-a4dc-66297e38cad3> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2003-09-12" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/8d5c5f54-a9c0-4d30-8736-38f350e943dc> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2018-01-31" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1100089> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-01-31" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/8db6af9d-aef9-48b7-9ae3-622ef13b91c6> <http://geneontology.org/lego/hint/layout/x> "8934.375"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "381.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1100089/093519c2-8bb6-4414-9b4b-bf79d479e2d1> ;
+	<http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_1100089/f0a5d328-3e34-4bab-a1ff-0f216ae08e56> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2018-02-22" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/8e64b707-88f5-4d57-9932-eff43dab9517> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2015-10-21" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2015-10-21" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:22437732" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/8e7a4c80-7ddd-4832-b9a8-6bae41683645> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2015-10-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2015-10-28" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:18269914" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/8f902b94-01c0-4334-8b56-affe62f529cd> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2018-02-22" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-02-22" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:17442941" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/91ece7be-7ffa-40f4-86be-074e063ce048> <http://geneontology.org/lego/hint/layout/x> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2013-01-09" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0055074> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/922b341f-766c-41de-8b24-efa9e0d195dc> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2013-01-09" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1100089> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2013-01-09" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/95094c4f-335a-4e08-9840-b42760a96357> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2018-02-22" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1100089> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-02-22" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/96299ba6-45db-4d45-a9c2-12ac0beaee8c> <http://geneontology.org/lego/evidence-with> "PR:O35235" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2003-10-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000353> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "binds itself (trimer)" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" , "https://orcid.org/0000-0003-2689-5511" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-03-17" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:11859102" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/98fb7eae-62a8-49d2-90e8-758f122a3388> <http://geneontology.org/lego/evidence-with> "MGI:MGI:1859962" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	a <http://purl.obolibrary.org/obo/ECO_0000315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "anatomy mammary gland alveolus ; MA:0002760" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2010-10-28" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:11051546" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/99750d1e-6561-4468-8502-2c1a5c10c1eb> <http://geneontology.org/lego/evidence-with> "MGI:MGI:104798" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2005-03-17" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000316> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "anatomy TS26\\ liver; EMAP:12229" , "cell type osteoclast ; CL:0000092 primary_cell_line ; CL:0000001" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-03-17" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:15485831" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/997edcf1-7754-47cb-a571-12ed1abe4544> <http://geneontology.org/lego/evidence-with> "MGI:MGI:109520" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2012-06-11" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000316> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "cell type primary cell line cell ; CL:0000001 osteoclast ; CL:0000092" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2012-06-11" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:22073305" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/9bdcc1bb-511b-4b96-a434-e3facbce2429> <http://geneontology.org/lego/hint/layout/x> "4603.125"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "687.5"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1100089/380a5f4b-0329-46ae-87d7-17a1bfae7e1d> ;
+	<http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_1100089/54dbca03-f4e9-4457-b2fd-2c8f2d92e9c2> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2005-03-17" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/9bf2332e-2fc9-4f1f-8cdb-81190e156da9> <http://geneontology.org/lego/hint/layout/x> "5390.625"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "381.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1100089/c6579ca4-ef10-48c0-af12-c808be709bba> ;
+	<http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_1100089/4aac0fab-0e4b-4972-909f-2d982cb1844e> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2014-03-27" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" , "https://orcid.org/0000-0003-3394-9805" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/9ccd6d81-ef1c-4a4c-b3b0-3d2e3f2c482f> <http://geneontology.org/lego/hint/layout/x> "1650"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2018-01-31" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0044691> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/9cea19ea-a4f1-4bd7-bcf0-73ab060b5a6c> <http://geneontology.org/lego/evidence-with> "MGI:MGI:99484" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2005-03-17" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000316> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "anatomy TS26\\ liver; EMAP:12229" , "cell type osteoclast ; CL:0000092 primary_cell_line ; CL:0000001" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-03-17" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:15485831" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/9d89ac91-9ddf-4894-9090-908ac596465d> <http://geneontology.org/lego/hint/layout/x> "1256.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2005-03-17" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CL_0000092> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/9e6ad43c-f097-4f59-928b-36e90d0c362b> <http://geneontology.org/lego/hint/layout/x> "6571.875"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "381.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1100089/ef580431-649a-4d41-bf2c-7d5e86d48cd2> ;
+	<http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_1100089/23cd23c1-33a3-4fc2-a380-131cc6690ec0> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2015-10-21" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/a072971e-f37b-4d6b-89d0-6ed11817c61c> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2012-06-11" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1100089> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2012-06-11" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/a1125cbe-8756-4121-9a87-fdb59da638ea> <http://geneontology.org/lego/hint/layout/x> "3028.125"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "381.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1100089/95094c4f-335a-4e08-9840-b42760a96357> ;
+	<http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_1100089/57336943-4437-4c32-a940-9c88ff0ad890> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2018-02-22" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/a22da629-679b-44d5-ab95-082039d87ea8> <http://geneontology.org/lego/hint/layout/x> "6178.125"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "687.5"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1100089/74fe2098-70a9-4715-9ef5-54965d35a170> ;
+	<http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_1100089/70953549-c4ea-4cab-b3a1-30b5f2443967> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/a2ae45c6-936e-449c-86e9-4be125d9fcce> <http://geneontology.org/lego/hint/layout/x> "10903.125"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "381.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1100089/6fafa7c7-b2f4-4efd-ba2b-2bc3a7a8d121> ;
+	<http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_1100089/ba1a0c31-0eaf-43cd-82cb-5303af1cb457> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2000-07-06" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> , "GOC:tc" ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/a41fb622-aecf-4e87-9310-13041ee9e48d> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2019-01-24" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "We found that the amount of a3 in the cytoskeletal fraction increased from 32% to 81% (" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2019-01-24" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:19715671" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/a7a0b7c8-a408-4309-abdd-b986dc1b01e3> <http://geneontology.org/lego/hint/layout/x> "2634.375"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "381.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1100089/c33cc31d-4eab-457f-a4b4-e5184f8f1925> ;
+	<http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_1100089/60fcf2b3-8aa2-47e8-81a9-203134ace208> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2004-04-30" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/a891d466-9b1e-4e19-b69e-936541d2769a> <http://geneontology.org/lego/evidence-with> "MGI:MGI:1339753" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2015-10-30" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000316> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "anatomy bone marrow ; MA:0000134" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2015-10-30" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:21048959" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/a8f58802-da21-452d-97e9-1f85b764c0e8> <http://geneontology.org/lego/hint/layout/x> "4209.375"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "381.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1100089/afcd09f8-751d-4f7e-bc56-9fcedb3782ab> ;
+	<http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_1100089/5b90a611-fb9d-48c2-a35d-1ea16a5c0dcc> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2015-03-19" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/a9716262-eb4e-45cf-bd06-a9c153a529dc> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2018-03-08" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-03-08" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:21841309" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/a9cc7906-f96b-495c-a7c9-b852d62aa96a> <http://geneontology.org/lego/hint/layout/x> "1846.875"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "381.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1100089/f9f8a5c0-5f9f-4024-96d4-1edefc875dbc> ;
+	<http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_1100089/82a20020-05ff-4458-adf9-7e9ffb7aaa5d> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2013-03-21" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/ad099715-8779-4315-b3cd-77a1c25a6177> <http://geneontology.org/lego/hint/layout/x> "7359.375"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "381.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1100089/cb50004f-882c-4f5d-b2ae-4ae321425a54> ;
+	<http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_1100089/1d74bc80-a582-4992-8545-edd5a1d48a1b> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2003-09-12" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" , "https://orcid.org/0000-0003-3394-9805" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/ad2745ba-630b-41de-8ab7-cb34fd113fc4> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "anatomy mammary gland epithelium ; MA:0000792" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2009-07-07" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:19298785" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/af610518-2fc7-4a3a-b70e-e366a55a1c03> <http://geneontology.org/lego/hint/layout/x> "9131.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/MGI_MGI_1100089/f8a2fd13-34a8-4cc5-833d-1a2dd82cff3a> ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0043491> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/afc04389-0b93-4c84-9367-66a4129484df> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2003-10-28" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1100089> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" , "https://orcid.org/0000-0003-2689-5511" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-03-17" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/afcd09f8-751d-4f7e-bc56-9fcedb3782ab> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2015-03-19" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1100089> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2015-03-19" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/b0dc50ca-fb75-4738-9bdb-5b252fd1f463> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2003-10-28" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/PR_O35235> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" , "https://orcid.org/0000-0003-2689-5511" ;
+	<http://purl.org/dc/elements/1.1/date> "2019-07-10" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/b2f4fdb9-e313-4d2e-80d6-d42204de492f> <http://geneontology.org/lego/evidence-with> "MGI:MGI:104798" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2005-03-17" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000316> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "anatomy TS26\\ liver; EMAP:12229" , "cell type osteoclast ; CL:0000092 primary_cell_line ; CL:0000001" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-03-17" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:15485831" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/b3389cb3-cec3-4e05-b665-360b7fc84de2> <http://geneontology.org/lego/evidence-with> "MGI:MGI:99484" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2005-03-17" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000316> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "anatomy TS26\\ liver; EMAP:12229" , "cell type osteoclast ; CL:0000092 primary_cell_line ; CL:0000001" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-03-17" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:15485831" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/b74c7fb0-c46e-4ce0-a927-756679ee9319> <http://geneontology.org/lego/evidence-with> "MGI:MGI:1859962" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	a <http://purl.obolibrary.org/obo/ECO_0000315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "cell type epithelial cell ; CL:0000066" , "anatomy mammary gland alveolus ; MA:0002760" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2009-07-07" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:11051546" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/b7db5cd6-3ca2-409e-ab3c-914f1d16b1ab> <http://geneontology.org/lego/evidence-with> "MGI:MGI:1859962" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	a <http://purl.obolibrary.org/obo/ECO_0000315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "cell type epithelial cell ; CL:0000066" , "anatomy mammary gland alveolus ; MA:0002760" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2009-07-07" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:11051546" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/ba1a0c31-0eaf-43cd-82cb-5303af1cb457> <http://geneontology.org/lego/hint/layout/x> "11493.75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2000-07-06" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0009887> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> , "GOC:tc" ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/ba372e5d-bafb-4494-a334-587b4cb9b65f> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2013-03-21" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2013-03-21" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:22451653" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/ba425eb8-0952-4b2e-b4ea-d7d77ef9606d> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2015-10-21" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2015-10-21" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:22437732" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/bdb568fd-4995-419a-97c3-9d342b1de576> <http://geneontology.org/lego/evidence-with> "MGI:MGI:1859962" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	a <http://purl.obolibrary.org/obo/ECO_0000315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "anatomy mammary gland alveolus ; MA:0002760" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2010-10-28" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:11051546" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/be2e0558-1e6a-47ba-a213-ba051fac4424> <http://geneontology.org/lego/evidence-with> "MGI:MGI:1339753" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2007-02-12" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000316> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "cell type primary cell line cell ; CL:0000001 osteoclast ; CL:0000092" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2007-02-12" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:17053831" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/c0beb774-354a-4781-b5b2-2cf27483011a> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2005-05-06" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1100089> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" , "https://orcid.org/0000-0002-9796-7693" , "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2015-10-30" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/c33cc31d-4eab-457f-a4b4-e5184f8f1925> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2004-04-30" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1100089> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2004-04-30" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/c4064270-28e4-48c4-bd26-c902dba456d2> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2017-06-14" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000270> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "mouse embryonic stem cells; expression decreased upon the induction of differentiation" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2017-06-14" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:20439489" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/c6579ca4-ef10-48c0-af12-c808be709bba> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2014-03-27" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1100089> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" , "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2015-10-28" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/c6776a2d-9b6a-42a1-9788-28ccadd79cee> <http://geneontology.org/lego/hint/layout/x> "7753.125"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "381.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1100089/f5f603dd-80a5-4471-8369-fd291fc1f865> ;
+	<http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_1100089/1a38828c-3d8c-4c93-b949-696551594a01> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2019-01-24" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/c85e2851-1027-4aa8-bc6b-039a256e444b> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2005-12-23" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "cell type osteoclast ; CL:0000092 primary_cell_line ; CL:0000001" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-12-23" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:15724149" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/c97fc108-04a9-4db5-a573-6427d4ecfa53> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2004-04-30" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2004-04-30" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:14662855" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/c99b18bf-b43f-4c41-a24b-56355d413801> <http://geneontology.org/lego/evidence-with> "MGI:MGI:1339753" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2007-02-12" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000316> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "cell type primary cell line cell ; CL:0000001 osteoclast ; CL:0000092" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2007-02-12" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:17053831" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/ca3d531f-ca55-4e0f-9d77-8aa9aba1457e> <http://geneontology.org/lego/evidence-with> "MGI:MGI:5614816" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2018-01-31" ;
+	a <http://purl.obolibrary.org/obo/ECO_0000315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-01-31" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:26234751" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/cb50004f-882c-4f5d-b2ae-4ae321425a54> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2003-09-12" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1100089> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" , "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2013-08-27" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/cccdadf9-9e0c-4ed2-bc47-7b513781a254> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2003-09-12" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2003-09-12" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:12490655" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/d1a35638-9490-4070-8a14-1672acd065d6> <http://geneontology.org/lego/evidence-with> "MGI:MGI:1859962" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2000-07-06" ;
+	a <http://purl.obolibrary.org/obo/ECO_0000315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "GOC:tc" ;
+	<http://purl.org/dc/elements/1.1/date> "2000-07-06" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:9950424" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/d45c5b9c-aaa9-45d6-af3a-3a8b7d1655be> <http://geneontology.org/lego/hint/layout/x> "5784.375"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "993.75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1100089/552aa0ac-1f95-4aa8-8ea8-7977d1ac0b56> ;
+	<http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_1100089/3a3838b0-4d69-4958-9f06-ca1cac5844ef> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2005-12-23" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/d4886d11-549c-4207-bb36-fbfa7aa1e1d3> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2015-10-21" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2015-10-21" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:22437732" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/d6410114-5508-468b-a040-20044461783e> <http://geneontology.org/lego/evidence-with> "MGI:MGI:99484" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2005-03-17" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000316> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "anatomy TS26\\ liver; EMAP:12229" , "cell type osteoclast ; CL:0000092 primary_cell_line ; CL:0000001" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-03-17" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:15485831" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/d7b70a30-f6af-461c-b1c3-4b86ca3d7bf7> <http://geneontology.org/lego/hint/layout/x> "10644"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "259"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/MGI_MGI_1100089/12c599a6-b1ae-4864-9173-e7b825a5a95e> ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0007249> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/d9394c0c-9910-4130-9455-b5e8381876b6> <http://geneontology.org/lego/evidence-with> "MGI:MGI:1859962" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2000-07-06" ;
+	a <http://purl.obolibrary.org/obo/ECO_0000315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "GOC:tc" ;
+	<http://purl.org/dc/elements/1.1/date> "2000-07-06" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:9950424" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/daa0ff62-bf1a-45f2-aa40-c757a7ae4158> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2000-07-06" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1100089> ;
+	<http://purl.org/dc/elements/1.1/contributor> "GOC:tc" ;
+	<http://purl.org/dc/elements/1.1/date> "2000-07-06" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/db7da93d-ea3b-47a1-ad68-ac9f5aba1516> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2018-02-22" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-02-22" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:17442941" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/df353207-b046-4bf5-9c10-54bdc50297ee> <http://geneontology.org/lego/evidence-with> "MGI:MGI:102469" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2013-01-09" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000316> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2013-01-09" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:21982707" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/e2a15cc9-72b8-45cb-851e-b45141a33e78> <http://geneontology.org/lego/hint/layout/x> "10706.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2000-08-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0048535> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-2689-5511" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> , "GOC:tc" ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/e34a8c11-d429-4598-82fa-0262b63671f6> <http://geneontology.org/lego/evidence-with> "MGI:MGI:1859962" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	a <http://purl.obolibrary.org/obo/ECO_0000315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "cell type epithelial cell ; CL:0000066" , "anatomy mammary gland epithelium ; MA:0000792" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2009-07-07" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:11051546" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/e3d3b9cf-5a6f-4d4f-a055-8dc6da521c79> <http://geneontology.org/lego/evidence-with> "MGI:MGI:2158925" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2013-01-09" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000316> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "cell type permanent cell line cell ; CLO:0000019 RAW 264.7 ; ATCC:TIB-71" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2013-01-09" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:21982707" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/e4b5adae-6a9c-4fad-b393-7ae104c6e041> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2000-08-07" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000304> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "lymph gland development obsoleted" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-2689-5511" , "GOC:tc" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-06-13" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:10687308" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/e57ef9a7-3ca1-4b24-9d9a-a7d2bea1dfff> <http://geneontology.org/lego/hint/layout/x> "10312.5"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2018-03-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0036035> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/e78ac428-5414-4adb-aacc-b34c4ec172c6> <http://geneontology.org/lego/hint/layout/x> "6571.875"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "687.5"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1100089/2bc03819-31d9-46f7-87df-b6b816140c6d> ;
+	<http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_1100089/29335aba-eda4-45ba-ac08-612cbd62f2d0> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/e7c3b75b-6ae7-4595-a3fe-6861e11d6c9c> <http://geneontology.org/lego/hint/layout/x> "9721.875"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "381.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1100089/6f54e095-d1a7-410a-a5a9-5c2e382e3c93> ;
+	<http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_1100089/e57ef9a7-3ca1-4b24-9d9a-a7d2bea1dfff> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2018-03-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/e8e74858-3148-4a87-8a08-edf519c375b0> <http://geneontology.org/lego/evidence-with> "MGI:MGI:5614816" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2018-01-31" ;
+	a <http://purl.obolibrary.org/obo/ECO_0000315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-01-31" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:26234751" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/eb2628fa-65fd-490f-85df-7d08723a60db> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2015-10-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2015-10-28" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:18269914" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/eb8d4b1c-4af5-4351-a23c-45686d1059d0> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2003-09-12" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2003-09-12" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:12490655" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/ef580431-649a-4d41-bf2c-7d5e86d48cd2> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2015-10-21" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1100089> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-02-22" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/f0a5d328-3e34-4bab-a1ff-0f216ae08e56> <http://geneontology.org/lego/hint/layout/x> "9918.75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/MGI_MGI_1100089/68247adb-1be4-4b33-a992-ae234f9f139d> ;
+	<http://purl.org/dc/terms/created> "2018-02-22" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0030316> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/f5e4516b-e7a0-4080-8f5d-b28d6318950c> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2014-03-27" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2014-03-27" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:23980096" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/f5f603dd-80a5-4471-8369-fd291fc1f865> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2019-01-24" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1100089> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2019-01-24" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/f8a2fd13-34a8-4cc5-833d-1a2dd82cff3a> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/EMAPA_17760> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2009-07-07" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/f9f8a5c0-5f9f-4024-96d4-1edefc875dbc> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2013-03-21" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1100089> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2013-03-21" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/fb73b191-9c07-41e0-a85b-c98566cace3d> <http://geneontology.org/lego/evidence-with> "MGI:MGI:1339753" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2007-02-12" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000316> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "cell type primary cell line cell ; CL:0000001 osteoclast ; CL:0000092" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2007-02-12" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:17053831" .
+
+<http://model.geneontology.org/MGI_MGI_1100089/fc51def0-a97d-4625-b501-bbd826cd264a> <http://geneontology.org/lego/hint/layout/x> "9525"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/EMAPA_36566> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1100089/fe66d09a-03f9-4797-997f-bf5cfdb7f616> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CL_0000066> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2009-07-07" .
+
+<http://purl.obolibrary.org/obo/GO_0002158> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0038001> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0044691> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0045672> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0071847> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_1904616> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/PR_O35235> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.org/dc/elements/1.1/title> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.org/dc/elements/1.1/contributor> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.org/dc/elements/1.1/date> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.org/dc/elements/1.1/source> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+_:t438398 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/80ffa85f-06fc-4170-8271-48492c1b8871> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/a1125cbe-8756-4121-9a87-fdb59da638ea> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/95094c4f-335a-4e08-9840-b42760a96357> ;
+	<http://purl.org/dc/terms/created> "2018-02-22" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0010628 MGI:MGI:3836131|PMID:17442941 ECO:0000314   2018-02-22 MGI RO:0002233(MGI:MGI:95574) creation-date=2018-02-22|modification-date=2018-02-22|contributor-id=https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-02-22" .
+
+_:t438399 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/8b39660d-6dab-49bd-93de-ba3b2f4b3ab6> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002418> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/a8f58802-da21-452d-97e9-1f85b764c0e8> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/5b90a611-fb9d-48c2-a35d-1ea16a5c0dcc> ;
+	<http://purl.org/dc/terms/created> "2015-03-19" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0038001 MGI:MGI:5576858|PMID:24190884 ECO:0000314   2015-03-19 MGI  creation-date=2015-03-19|modification-date=2015-03-19|contributor-id=https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2015-03-19" .
+
+_:t438400 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/0c0222c9-e115-41ec-a90f-24374cbd3a30> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/a9cc7906-f96b-495c-a7c9-b852d62aa96a> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/f9f8a5c0-5f9f-4024-96d4-1edefc875dbc> ;
+	<http://purl.org/dc/terms/created> "2013-03-21" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0002158 MGI:MGI:5467208|PMID:22451653 ECO:0000314   2013-03-21 MGI  creation-date=2013-03-21|modification-date=2013-03-21|contributor-id=https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2013-03-21" .
+
+_:t438401 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/ba372e5d-bafb-4494-a334-587b4cb9b65f> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002418> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/a9cc7906-f96b-495c-a7c9-b852d62aa96a> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/82a20020-05ff-4458-adf9-7e9ffb7aaa5d> ;
+	<http://purl.org/dc/terms/created> "2013-03-21" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0002158 MGI:MGI:5467208|PMID:22451653 ECO:0000314   2013-03-21 MGI  creation-date=2013-03-21|modification-date=2013-03-21|contributor-id=https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2013-03-21" .
+
+_:t438402 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/865e84da-740f-4a57-8d30-2be6f695f202> , <http://model.geneontology.org/MGI_MGI_1100089/8743ce71-9ea0-4d8a-b04c-f33146caeb32> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/ad099715-8779-4315-b3cd-77a1c25a6177> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/cb50004f-882c-4f5d-b2ae-4ae321425a54> ;
+	<http://purl.org/dc/terms/created> "2003-09-12" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0045670 MGI:MGI:2448204|PMID:12490655 ECO:0000314   2003-09-12 MGI  creation-date=2003-09-12|modification-date=2003-09-12|contributor-id=https://orcid.org/0000-0002-9796-7693" , "MGI:MGI:1100089  RO:0002264 GO:0045670 MGI:MGI:5495340|PMID:23395171 ECO:0000314   2013-08-27 MGI  creation-date=2013-08-27|modification-date=2013-08-27|contributor-id=https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" , "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2013-08-27" .
+
+_:t438403 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/7d673a97-cb4e-4f95-bc56-70242f3eed53> , <http://model.geneontology.org/MGI_MGI_1100089/eb8d4b1c-4af5-4351-a23c-45686d1059d0> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002418> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/ad099715-8779-4315-b3cd-77a1c25a6177> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/1d74bc80-a582-4992-8545-edd5a1d48a1b> ;
+	<http://purl.org/dc/terms/created> "2003-09-12" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0045670 MGI:MGI:2448204|PMID:12490655 ECO:0000314   2003-09-12 MGI  creation-date=2003-09-12|modification-date=2003-09-12|contributor-id=https://orcid.org/0000-0002-9796-7693" , "MGI:MGI:1100089  RO:0002264 GO:0045670 MGI:MGI:5495340|PMID:23395171 ECO:0000314   2013-08-27 MGI  creation-date=2013-08-27|modification-date=2013-08-27|contributor-id=https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" , "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2013-08-27" .
+
+_:t438404 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/4d4ece49-7ca5-48d9-a2e8-ddab30db87fb> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000066> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/af610518-2fc7-4a3a-b70e-e366a55a1c03> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/f8a2fd13-34a8-4cc5-833d-1a2dd82cff3a> ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0051897 MGI:MGI:1889907|PMID:11051546 ECO:0000315 MGI:MGI:1859962  2009-07-07 MGI GOREL:0001004(CL:0000066),GOREL:0001004(EMAPA:17760) creation-date=2009-07-07|modification-date=2009-07-07|comment=anatomy mammary gland epithelium ; MA:0000792|comment=cell type epithelial cell ; CL:0000066|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2009-07-07" .
+
+_:t438405 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/0af03b2c-a62f-4743-971d-4f9af273cf15> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/c6776a2d-9b6a-42a1-9788-28ccadd79cee> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/f5f603dd-80a5-4471-8369-fd291fc1f865> ;
+	<http://purl.org/dc/terms/created> "2019-01-24" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:1904616 MGI:MGI:4365671|PMID:19715671 ECO:0000314   2019-01-24 MGI  creation-date=2019-01-24|modification-date=2019-01-24|comment=We found that the amount of a3 in the cytoskeletal fraction increased from 32% to 81% (|contributor-id=https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2019-01-24" .
+
+_:t438406 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/a41fb622-aecf-4e87-9310-13041ee9e48d> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002418> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/c6776a2d-9b6a-42a1-9788-28ccadd79cee> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/1a38828c-3d8c-4c93-b949-696551594a01> ;
+	<http://purl.org/dc/terms/created> "2019-01-24" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:1904616 MGI:MGI:4365671|PMID:19715671 ECO:0000314   2019-01-24 MGI  creation-date=2019-01-24|modification-date=2019-01-24|comment=We found that the amount of a3 in the cytoskeletal fraction increased from 32% to 81% (|contributor-id=https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2019-01-24" .
+
+_:t438407 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/c85e2851-1027-4aa8-bc6b-039a256e444b> , <http://model.geneontology.org/MGI_MGI_1100089/c99b18bf-b43f-4c41-a24b-56355d413801> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/d45c5b9c-aaa9-45d6-af3a-3a8b7d1655be> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/552aa0ac-1f95-4aa8-8ea8-7977d1ac0b56> ;
+	<http://purl.org/dc/terms/created> "2005-12-23" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0045672 MGI:MGI:3689489|PMID:17053831 ECO:0000316 MGI:MGI:1339753  2007-02-12 MGI GOREL:0001010(CL:0000092) creation-date=2007-02-12|modification-date=2007-02-12|comment=cell type primary cell line cell ; CL:0000001 osteoclast ; CL:0000092|contributor-id=https://orcid.org/0000-0001-7476-6306" , "MGI:MGI:1100089  RO:0002264 GO:0045672 MGI:MGI:3575849|PMID:15724149 ECO:0000314   2005-12-23 MGI GOREL:0001010(CL:0000092) creation-date=2005-12-23|modification-date=2005-12-23|comment=cell type osteoclast ; CL:0000092 primary_cell_line ; CL:0000001|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2007-02-12" .
+
+_:t438408 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/5754568e-bcf6-47ec-bd81-29ca39324917> , <http://model.geneontology.org/MGI_MGI_1100089/7e696abb-bff9-40f5-a04e-275ec696aebc> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002418> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/d45c5b9c-aaa9-45d6-af3a-3a8b7d1655be> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/3a3838b0-4d69-4958-9f06-ca1cac5844ef> ;
+	<http://purl.org/dc/terms/created> "2005-12-23" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0045672 MGI:MGI:3689489|PMID:17053831 ECO:0000316 MGI:MGI:1339753  2007-02-12 MGI GOREL:0001010(CL:0000092) creation-date=2007-02-12|modification-date=2007-02-12|comment=cell type primary cell line cell ; CL:0000001 osteoclast ; CL:0000092|contributor-id=https://orcid.org/0000-0001-7476-6306" , "MGI:MGI:1100089  RO:0002264 GO:0045672 MGI:MGI:3575849|PMID:15724149 ECO:0000314   2005-12-23 MGI GOREL:0001010(CL:0000092) creation-date=2005-12-23|modification-date=2005-12-23|comment=cell type osteoclast ; CL:0000092 primary_cell_line ; CL:0000001|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2007-02-12" .
+
+_:t438409 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/71c1b1f0-9b81-4127-aea9-4a5d420ab5f1> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002418> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/a1125cbe-8756-4121-9a87-fdb59da638ea> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/57336943-4437-4c32-a940-9c88ff0ad890> ;
+	<http://purl.org/dc/terms/created> "2018-02-22" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0010628 MGI:MGI:3836131|PMID:17442941 ECO:0000314   2018-02-22 MGI RO:0002233(MGI:MGI:95574) creation-date=2018-02-22|modification-date=2018-02-22|contributor-id=https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-02-22" .
+
+_:t438410 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/ad2745ba-630b-41de-8ab7-cb34fd113fc4> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000066> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/d7b70a30-f6af-461c-b1c3-4b86ca3d7bf7> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/12c599a6-b1ae-4864-9173-e7b825a5a95e> ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0043123 MGI:MGI:3848090|PMID:19298785 ECO:0000314   2009-07-07 MGI GOREL:0001004(EMAPA:17760) creation-date=2009-07-07|modification-date=2009-07-07|comment=anatomy mammary gland epithelium ; MA:0000792|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2009-07-07" .
+
+_:t438411 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/bdb568fd-4995-419a-97c3-9d342b1de576> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/e78ac428-5414-4adb-aacc-b34c4ec172c6> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/2bc03819-31d9-46f7-87df-b6b816140c6d> ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0060749 MGI:MGI:1889907|PMID:11051546 ECO:0000315 MGI:MGI:1859962  2010-10-28 MGI RO:0002296(EMAPA:36566) creation-date=2009-07-07|modification-date=2010-10-28|comment=anatomy mammary gland alveolus ; MA:0002760|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2010-10-28" .
+
+_:t438412 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/1806437c-37fe-40ad-b132-72ff76b48392> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002418> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/e78ac428-5414-4adb-aacc-b34c4ec172c6> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/29335aba-eda4-45ba-ac08-612cbd62f2d0> ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0060749 MGI:MGI:1889907|PMID:11051546 ECO:0000315 MGI:MGI:1859962  2010-10-28 MGI RO:0002296(EMAPA:36566) creation-date=2009-07-07|modification-date=2010-10-28|comment=anatomy mammary gland alveolus ; MA:0002760|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2010-10-28" .
+
+_:t438413 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/115479f4-8c64-438a-90cf-f9908f9a6513> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/e7c3b75b-6ae7-4595-a3fe-6861e11d6c9c> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/6f54e095-d1a7-410a-a5a9-5c2e382e3c93> ;
+	<http://purl.org/dc/terms/created> "2018-03-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0036035 MGI:MGI:5297759|PMID:21841309 ECO:0000314   2018-03-08 MGI  creation-date=2018-03-08|modification-date=2018-03-08|contributor-id=https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-03-08" .
+
+_:t438414 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/a9716262-eb4e-45cf-bd06-a9c153a529dc> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002418> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/e7c3b75b-6ae7-4595-a3fe-6861e11d6c9c> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/e57ef9a7-3ca1-4b24-9d9a-a7d2bea1dfff> ;
+	<http://purl.org/dc/terms/created> "2018-03-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0036035 MGI:MGI:5297759|PMID:21841309 ECO:0000314   2018-03-08 MGI  creation-date=2018-03-08|modification-date=2018-03-08|contributor-id=https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-03-08" .
+
+_:t438415 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/34d3f2f3-dd82-4932-a528-4873441aaa9f> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000066> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/f0a5d328-3e34-4bab-a1ff-0f216ae08e56> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/68247adb-1be4-4b33-a992-ae234f9f139d> ;
+	<http://purl.org/dc/terms/created> "2018-02-22" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0030316 MGI:MGI:3836131|PMID:17442941 ECO:0000314   2018-02-22 MGI BFO:0000066(CL:0002476) creation-date=2018-02-22|modification-date=2018-02-22|contributor-id=https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-02-22" .
+
+_:t438416 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/813644a5-1c76-40f8-967a-ab7044abb336> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002233> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/0ad06254-0f74-4162-9360-30f2522d278e> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/b0dc50ca-fb75-4738-9bdb-5b252fd1f463> ;
+	<http://purl.org/dc/terms/created> "2003-10-28" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002327 GO:0042802 MGI:MGI:2159081|PMID:11859102 ECO:0000353 PR:O35235  2019-07-10 MGI  creation-date=2003-10-28|modification-date=2019-07-10|comment=forms trimer (as determined by X-ray structure|contributor-id=https://orcid.org/0000-0002-9796-7693|contributor-id=https://orcid.org/0000-0003-2689-5511" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" , "https://orcid.org/0000-0003-2689-5511" ;
+	<http://purl.org/dc/elements/1.1/date> "2019-07-10" .
+
+_:t438417 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/0bda47fe-9143-4225-bd2f-10c3c95aa477> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/0ad06254-0f74-4162-9360-30f2522d278e> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/536cbcb7-b338-4e95-a290-88449707d3c2> ;
+	<http://purl.org/dc/terms/created> "2003-10-28" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002327 GO:0042802 MGI:MGI:2159081|PMID:11859102 ECO:0000353 PR:O35235  2019-07-10 MGI  creation-date=2003-10-28|modification-date=2019-07-10|comment=forms trimer (as determined by X-ray structure|contributor-id=https://orcid.org/0000-0002-9796-7693|contributor-id=https://orcid.org/0000-0003-2689-5511" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" , "https://orcid.org/0000-0003-2689-5511" ;
+	<http://purl.org/dc/elements/1.1/date> "2019-07-10" .
+
+_:t438418 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/e3d3b9cf-5a6f-4d4f-a055-8dc6da521c79> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/0cebddcc-7747-47f3-b390-ad238a531adf> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/922b341f-766c-41de-8b24-efa9e0d195dc> ;
+	<http://purl.org/dc/terms/created> "2013-01-09" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0055074 MGI:MGI:5295788|PMID:21982707 ECO:0000316 MGI:MGI:2158925  2013-01-09 MGI  creation-date=2013-01-09|modification-date=2013-01-09|comment=cell type permanent cell line cell ; CLO:0000019 RAW 264.7 ; ATCC:TIB-71|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2013-01-09" .
+
+_:t438419 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/52d9419f-ff84-4bdd-8ea0-eb550b1b82e2> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002418> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/0cebddcc-7747-47f3-b390-ad238a531adf> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/91ece7be-7ffa-40f4-86be-074e063ce048> ;
+	<http://purl.org/dc/terms/created> "2013-01-09" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0055074 MGI:MGI:5295788|PMID:21982707 ECO:0000316 MGI:MGI:2158925  2013-01-09 MGI  creation-date=2013-01-09|modification-date=2013-01-09|comment=cell type permanent cell line cell ; CLO:0000019 RAW 264.7 ; ATCC:TIB-71|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2013-01-09" .
+
+_:t438420 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/25f475f8-9995-45ed-8dd8-1e2f780c3d58> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/a22da629-679b-44d5-ab95-082039d87ea8> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/74fe2098-70a9-4715-9ef5-54965d35a170> ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0051897 MGI:MGI:1889907|PMID:11051546 ECO:0000315 MGI:MGI:1859962  2009-07-07 MGI GOREL:0001004(CL:0000066),GOREL:0001004(EMAPA:17760) creation-date=2009-07-07|modification-date=2009-07-07|comment=anatomy mammary gland epithelium ; MA:0000792|comment=cell type epithelial cell ; CL:0000066|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2009-07-07" .
+
+_:t438421 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/4f8a7b22-eaab-4c0a-a150-de435ae25455> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002213> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/0de20908-1afe-42fb-9912-d4e0bfc6b063> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/0949b10b-153f-4204-878e-6ab89d10fecb> ;
+	<http://purl.org/dc/terms/created> "2012-06-11" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0046330 MGI:MGI:5308511|PMID:22073305 ECO:0000316 MGI:MGI:109520  2012-06-11 MGI GOREL:0001004(CL:0000092) creation-date=2012-06-11|modification-date=2012-06-11|comment=cell type primary cell line cell ; CL:0000001 osteoclast ; CL:0000092|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2012-06-11" .
+
+_:t438422 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/479e4f7e-bd4d-40f8-b587-dcf4bf44a751> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000066> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/02dc2866-9e33-4e1f-a5bc-53f5192066dc> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/fe66d09a-03f9-4797-997f-bf5cfdb7f616> ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0051897 MGI:MGI:1889907|PMID:11051546 ECO:0000315 MGI:MGI:1859962  2009-07-07 MGI GOREL:0001004(CL:0000066),GOREL:0001004(EMAPA:17760) creation-date=2009-07-07|modification-date=2009-07-07|comment=anatomy mammary gland epithelium ; MA:0000792|comment=cell type epithelial cell ; CL:0000066|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2009-07-07" .
+
+_:t438423 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/85dec380-e8ba-4bd2-857d-40ca62e5b1cf> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000066> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/0949b10b-153f-4204-878e-6ab89d10fecb> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/8a9b9a1d-c14e-4f83-a3a9-95c1f71e5363> ;
+	<http://purl.org/dc/terms/created> "2012-06-11" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0046330 MGI:MGI:5308511|PMID:22073305 ECO:0000316 MGI:MGI:109520  2012-06-11 MGI GOREL:0001004(CL:0000092) creation-date=2012-06-11|modification-date=2012-06-11|comment=cell type primary cell line cell ; CL:0000001 osteoclast ; CL:0000092|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2012-06-11" .
+
+_:t438424 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/71572243-1978-46a7-acec-40e21e2022e9> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/11c4f543-3f2d-4e19-ba53-6a2502d8740f> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/3151c07b-4947-461a-8d43-9683fed21b96> ;
+	<http://purl.org/dc/terms/created> "2019-01-24" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0010628 MGI:MGI:4365671|PMID:19715671 ECO:0000314   2019-01-24 MGI  creation-date=2019-01-24|modification-date=2019-01-24|comment=target Tcirg1;MGI:1350931|comment=The murine microglial cell line N9 ; RANKL stimulated increased the relative expression of subunit a3|contributor-id=https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2019-01-24" .
+
+_:t438425 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/0458fa3d-573d-4e5b-8b78-258baa989cad> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002418> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/11c4f543-3f2d-4e19-ba53-6a2502d8740f> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/2e4bf66c-dc08-4cf2-b6e6-b57ffdbede23> ;
+	<http://purl.org/dc/terms/created> "2019-01-24" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0010628 MGI:MGI:4365671|PMID:19715671 ECO:0000314   2019-01-24 MGI  creation-date=2019-01-24|modification-date=2019-01-24|comment=target Tcirg1;MGI:1350931|comment=The murine microglial cell line N9 ; RANKL stimulated increased the relative expression of subunit a3|contributor-id=https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2019-01-24" .
+
+_:t438426 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/6ef8de1b-1329-446a-a882-5cd5146328cd> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/14d813d6-6505-4bb4-a7e3-e5ea0d4e7ef4> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/a072971e-f37b-4d6b-89d0-6ed11817c61c> ;
+	<http://purl.org/dc/terms/created> "2012-06-11" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0046330 MGI:MGI:5308511|PMID:22073305 ECO:0000316 MGI:MGI:109520  2012-06-11 MGI GOREL:0001004(CL:0000092) creation-date=2012-06-11|modification-date=2012-06-11|comment=cell type primary cell line cell ; CL:0000001 osteoclast ; CL:0000092|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2012-06-11" .
+
+_:t438427 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/997edcf1-7754-47cb-a571-12ed1abe4544> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002418> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/14d813d6-6505-4bb4-a7e3-e5ea0d4e7ef4> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/0de20908-1afe-42fb-9912-d4e0bfc6b063> ;
+	<http://purl.org/dc/terms/created> "2012-06-11" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0046330 MGI:MGI:5308511|PMID:22073305 ECO:0000316 MGI:MGI:109520  2012-06-11 MGI GOREL:0001004(CL:0000092) creation-date=2012-06-11|modification-date=2012-06-11|comment=cell type primary cell line cell ; CL:0000001 osteoclast ; CL:0000092|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2012-06-11" .
+
+_:t438428 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/c4064270-28e4-48c4-bd26-c902dba456d2> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/2e58dc0f-f2ce-40a9-8ed4-e715db160346> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/1d1c5018-3a8e-45da-afe2-83b5137ee791> ;
+	<http://purl.org/dc/terms/created> "2017-06-14" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:1990830 MGI:MGI:4822296|PMID:20439489 ECO:0000270   2017-06-14 MGI  creation-date=2017-06-14|modification-date=2017-06-14|comment=mouse embryonic stem cells; expression decreased upon the induction of differentiation|contributor-id=https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2017-06-14" .
+
+_:t438429 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/80baa21f-d09c-4c17-933a-04c7817687e4> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002418> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/2e58dc0f-f2ce-40a9-8ed4-e715db160346> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/53718c9c-32b7-488f-b0a8-e3d06c5adb40> ;
+	<http://purl.org/dc/terms/created> "2017-06-14" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:1990830 MGI:MGI:4822296|PMID:20439489 ECO:0000270   2017-06-14 MGI  creation-date=2017-06-14|modification-date=2017-06-14|comment=mouse embryonic stem cells; expression decreased upon the induction of differentiation|contributor-id=https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2017-06-14" .
+
+_:t438430 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/0899406b-8e55-4502-ace5-77606e4737c3> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/2036c49b-448b-41f5-a113-5eadc3596f48> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/8d5c5f54-a9c0-4d30-8736-38f350e943dc> ;
+	<http://purl.org/dc/terms/created> "2018-01-31" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0044691 MGI:MGI:5646594|PMID:26234751 ECO:0000315 MGI:MGI:5614816  2018-01-31 MGI  creation-date=2018-01-31|modification-date=2018-01-31|contributor-id=https://orcid.org/0000-0001-5501-853X" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-01-31" .
+
+_:t438431 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/57d511d7-a557-4735-9117-861dc720ab79> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002418> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/a22da629-679b-44d5-ab95-082039d87ea8> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/70953549-c4ea-4cab-b3a1-30b5f2443967> ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0051897 MGI:MGI:1889907|PMID:11051546 ECO:0000315 MGI:MGI:1859962  2009-07-07 MGI GOREL:0001004(CL:0000066),GOREL:0001004(EMAPA:17760) creation-date=2009-07-07|modification-date=2009-07-07|comment=anatomy mammary gland epithelium ; MA:0000792|comment=cell type epithelial cell ; CL:0000066|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2009-07-07" .
+
+_:t438432 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/1a8cb1c0-7aef-430c-9c59-958bc8f4f974> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002418> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/2036c49b-448b-41f5-a113-5eadc3596f48> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/9ccd6d81-ef1c-4a4c-b3b0-3d2e3f2c482f> ;
+	<http://purl.org/dc/terms/created> "2018-01-31" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0044691 MGI:MGI:5646594|PMID:26234751 ECO:0000315 MGI:MGI:5614816  2018-01-31 MGI  creation-date=2018-01-31|modification-date=2018-01-31|contributor-id=https://orcid.org/0000-0001-5501-853X" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-01-31" .
+
+_:t438433 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/98fb7eae-62a8-49d2-90e8-758f122a3388> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002296> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/29335aba-eda4-45ba-ac08-612cbd62f2d0> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/fc51def0-a97d-4625-b501-bbd826cd264a> ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0060749 MGI:MGI:1889907|PMID:11051546 ECO:0000315 MGI:MGI:1859962  2010-10-28 MGI RO:0002296(EMAPA:36566) creation-date=2009-07-07|modification-date=2010-10-28|comment=anatomy mammary gland alveolus ; MA:0002760|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2010-10-28" .
+
+_:t438434 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/0c026612-109f-4a92-99e8-54f27613dc0f> , <http://model.geneontology.org/MGI_MGI_1100089/fb73b191-9c07-41e0-a85b-c98566cace3d> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002213> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/3a3838b0-4d69-4958-9f06-ca1cac5844ef> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/85b039b9-df79-4b01-bca4-d3cfc681a3be> ;
+	<http://purl.org/dc/terms/created> "2005-12-23" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0045672 MGI:MGI:3689489|PMID:17053831 ECO:0000316 MGI:MGI:1339753  2007-02-12 MGI GOREL:0001010(CL:0000092) creation-date=2007-02-12|modification-date=2007-02-12|comment=cell type primary cell line cell ; CL:0000001 osteoclast ; CL:0000092|contributor-id=https://orcid.org/0000-0001-7476-6306" , "MGI:MGI:1100089  RO:0002264 GO:0045672 MGI:MGI:3575849|PMID:15724149 ECO:0000314   2005-12-23 MGI GOREL:0001010(CL:0000092) creation-date=2005-12-23|modification-date=2005-12-23|comment=cell type osteoclast ; CL:0000092 primary_cell_line ; CL:0000001|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2007-02-12" .
+
+_:t438435 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/3c3d184d-ec65-4e0f-9136-eda837b3dbc5> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002213> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/3d33b4d3-16e1-4eb6-a9c8-55d237a4763f> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/d7b70a30-f6af-461c-b1c3-4b86ca3d7bf7> ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0043123 MGI:MGI:3848090|PMID:19298785 ECO:0000314   2009-07-07 MGI GOREL:0001004(EMAPA:17760) creation-date=2009-07-07|modification-date=2009-07-07|comment=anatomy mammary gland epithelium ; MA:0000792|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2009-07-07" .
+
+_:t438436 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/e4b5adae-6a9c-4fad-b393-7ae104c6e041> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/34423773-244e-48c5-ae4d-bac5563785aa> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/4baaee02-2e20-4772-a7b8-66bdbffbf6e8> ;
+	<http://purl.org/dc/terms/created> "2000-08-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0048535 MGI:MGI:1353335|PMID:10687308 ECO:0000304   2005-06-13 MGI  creation-date=2000-08-07|modification-date=2005-06-13|comment=lymph gland development obsoleted|contributor-id=https://orcid.org/0000-0003-2689-5511|contributor-id=GOC:tc|contributor-id=https://orcid.org/0000-0003-2689-5511" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-2689-5511" , "GOC:tc" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-06-13" .
+
+_:t438437 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/372ff363-e619-4aa1-b877-7ca3bdfe64a7> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002418> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/34423773-244e-48c5-ae4d-bac5563785aa> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/e2a15cc9-72b8-45cb-851e-b45141a33e78> ;
+	<http://purl.org/dc/terms/created> "2000-08-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0048535 MGI:MGI:1353335|PMID:10687308 ECO:0000304   2005-06-13 MGI  creation-date=2000-08-07|modification-date=2005-06-13|comment=lymph gland development obsoleted|contributor-id=https://orcid.org/0000-0003-2689-5511|contributor-id=GOC:tc|contributor-id=https://orcid.org/0000-0003-2689-5511" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-2689-5511" , "GOC:tc" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-06-13" .
+
+_:t438438 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/65039e8700001566> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000050> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/382b0d09-5b99-40a5-a1eb-30df545e024b> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/3d33b4d3-16e1-4eb6-a9c8-55d237a4763f> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-09-27"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+_:t438439 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/0f34029b-72e0-41bd-a157-22d3e3327153> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/382b0d09-5b99-40a5-a1eb-30df545e024b> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/3cbb43ea-417c-4fb6-9c2a-48c4b7469c04> ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0043123 MGI:MGI:3848090|PMID:19298785 ECO:0000314   2009-07-07 MGI GOREL:0001004(EMAPA:17760) creation-date=2009-07-07|modification-date=2009-07-07|comment=anatomy mammary gland epithelium ; MA:0000792|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2009-07-07" .
+
+_:t438440 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/ca3d531f-ca55-4e0f-9d77-8aa9aba1457e> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/435df2bc-2186-4a4a-893f-ef9180a0c084> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/00ff48b9-1f29-414a-a9fe-30fbf7f0b3f2> ;
+	<http://purl.org/dc/terms/created> "2018-01-31" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0060348 MGI:MGI:5646594|PMID:26234751 ECO:0000315 MGI:MGI:5614816  2018-01-31 MGI  creation-date=2018-01-31|modification-date=2018-01-31|contributor-id=https://orcid.org/0000-0001-5501-853X" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-01-31" .
+
+_:t438441 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/e8e74858-3148-4a87-8a08-edf519c375b0> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002418> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/435df2bc-2186-4a4a-893f-ef9180a0c084> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/7a4e1c56-8d5b-4bda-ba62-93d3ac8e1923> ;
+	<http://purl.org/dc/terms/created> "2018-01-31" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0060348 MGI:MGI:5646594|PMID:26234751 ECO:0000315 MGI:MGI:5614816  2018-01-31 MGI  creation-date=2018-01-31|modification-date=2018-01-31|contributor-id=https://orcid.org/0000-0001-5501-853X" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-01-31" .
+
+_:t438442 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/0fa618e9-69a0-4770-9761-8870f11773db> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/a2ae45c6-936e-449c-86e9-4be125d9fcce> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/6fafa7c7-b2f4-4efd-ba2b-2bc3a7a8d121> ;
+	<http://purl.org/dc/terms/created> "2000-07-06" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0009887 MGI:MGI:1329208|PMID:9950424 ECO:0000315 MGI:MGI:1859962  2000-07-06 MGI  creation-date=2000-07-06|modification-date=2000-07-06|contributor-id=GOC:tc" ;
+	<http://purl.org/dc/elements/1.1/contributor> "GOC:tc" ;
+	<http://purl.org/dc/elements/1.1/date> "2000-07-06" .
+
+_:t438443 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/96299ba6-45db-4d45-a9c2-12ac0beaee8c> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002233> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/49b44f0e-6e30-4905-a871-6cff1cac5fd5> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/436eeaa0-d705-4468-b374-8b8476998c70> ;
+	<http://purl.org/dc/terms/created> "2003-10-28" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002327 GO:0005515 MGI:MGI:2159081|PMID:11859102 ECO:0000353 PR:O35235  2005-03-17 MGI  creation-date=2003-10-28|modification-date=2005-03-17|comment=binds itself (trimer)|contributor-id=https://orcid.org/0000-0001-7476-6306|contributor-id=https://orcid.org/0000-0003-2689-5511" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-2689-5511" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2005-03-17" .
+
+_:t438444 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/154be8f3-3240-40b2-865f-81c0bfcf5a9c> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/49b44f0e-6e30-4905-a871-6cff1cac5fd5> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/afc04389-0b93-4c84-9367-66a4129484df> ;
+	<http://purl.org/dc/terms/created> "2003-10-28" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002327 GO:0005515 MGI:MGI:2159081|PMID:11859102 ECO:0000353 PR:O35235  2005-03-17 MGI  creation-date=2003-10-28|modification-date=2005-03-17|comment=binds itself (trimer)|contributor-id=https://orcid.org/0000-0001-7476-6306|contributor-id=https://orcid.org/0000-0003-2689-5511" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-2689-5511" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2005-03-17" .
+
+_:t438445 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/d9394c0c-9910-4130-9455-b5e8381876b6> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/52fb87fb-70e5-4e9f-8aa4-508307c8918b> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/daa0ff62-bf1a-45f2-aa40-c757a7ae4158> ;
+	<http://purl.org/dc/terms/created> "2000-07-06" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0001503 MGI:MGI:1329208|PMID:9950424 ECO:0000315 MGI:MGI:1859962  2000-07-06 MGI  creation-date=2000-07-06|modification-date=2000-07-06|contributor-id=GOC:tc" ;
+	<http://purl.org/dc/elements/1.1/contributor> "GOC:tc" ;
+	<http://purl.org/dc/elements/1.1/date> "2000-07-06" .
+
+_:t438446 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/10323e33-78d3-4bfb-9c8f-5e93e3283cf6> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002418> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/52fb87fb-70e5-4e9f-8aa4-508307c8918b> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/5f35f4a9-05fd-4c37-92b2-a9e38b8d3bef> ;
+	<http://purl.org/dc/terms/created> "2000-07-06" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0001503 MGI:MGI:1329208|PMID:9950424 ECO:0000315 MGI:MGI:1859962  2000-07-06 MGI  creation-date=2000-07-06|modification-date=2000-07-06|contributor-id=GOC:tc" ;
+	<http://purl.org/dc/elements/1.1/contributor> "GOC:tc" ;
+	<http://purl.org/dc/elements/1.1/date> "2000-07-06" .
+
+_:t438447 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/63f9aa13-dfd7-4267-a798-aa5e93d6cb81> , <http://model.geneontology.org/MGI_MGI_1100089/9cea19ea-a4f1-4bd7-bcf0-73ab060b5a6c> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000066> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/54dbca03-f4e9-4457-b2fd-2c8f2d92e9c2> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/47e18425-8745-4005-a8f2-fe7cbc9eb369> ;
+	<http://purl.org/dc/terms/created> "2005-03-17" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0030316 MGI:MGI:3525391|PMID:15485831 ECO:0000316 MGI:MGI:104798|MGI:MGI:99484  2005-03-17 MGI BFO:0000066(EMAPA:16846),RO:0002315(CL:0000092) creation-date=2005-03-17|modification-date=2005-03-17|comment=anatomy TS26\\ liver; EMAP:12229|comment=cell type osteoclast ; CL:0000092 primary_cell_line ; CL:0000001|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2005-03-17" .
+
+_:t438448 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/885748da-acf1-4504-8dda-2522e1ca26bb> , <http://model.geneontology.org/MGI_MGI_1100089/d6410114-5508-468b-a040-20044461783e> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002315> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/54dbca03-f4e9-4457-b2fd-2c8f2d92e9c2> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/9d89ac91-9ddf-4894-9090-908ac596465d> ;
+	<http://purl.org/dc/terms/created> "2005-03-17" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0030316 MGI:MGI:3525391|PMID:15485831 ECO:0000316 MGI:MGI:104798|MGI:MGI:99484  2005-03-17 MGI BFO:0000066(EMAPA:16846),RO:0002315(CL:0000092) creation-date=2005-03-17|modification-date=2005-03-17|comment=anatomy TS26\\ liver; EMAP:12229|comment=cell type osteoclast ; CL:0000092 primary_cell_line ; CL:0000001|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2005-03-17" .
+
+_:t438449 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/db7da93d-ea3b-47a1-ad68-ac9f5aba1516> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002233> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/57336943-4437-4c32-a940-9c88ff0ad890> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/5701d88b-e3c2-418d-bb80-c0e42f25fe39> ;
+	<http://purl.org/dc/terms/created> "2018-02-22" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0010628 MGI:MGI:3836131|PMID:17442941 ECO:0000314   2018-02-22 MGI RO:0002233(MGI:MGI:95574) creation-date=2018-02-22|modification-date=2018-02-22|contributor-id=https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-02-22" .
+
+_:t438450 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/b7db5cd6-3ca2-409e-ab3c-914f1d16b1ab> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/58d0f505-7944-46e0-a998-22274b434b36> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/42548bce-2619-4a37-9b74-c0563f3ce7f6> ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0033598 MGI:MGI:1889907|PMID:11051546 ECO:0000315 MGI:MGI:1859962  2009-07-07 MGI BFO:0000066(EMAPA:36566),RO:0012003(CL:0000066) creation-date=2009-07-07|modification-date=2009-07-07|comment=anatomy mammary gland alveolus ; MA:0002760|comment=cell type epithelial cell ; CL:0000066|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2009-07-07" .
+
+_:t438451 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/54ab1568-75a4-4dfc-8130-198487e64b6e> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002418> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/58d0f505-7944-46e0-a998-22274b434b36> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/8b23580a-252b-463b-bc29-4f606bdc66c1> ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0033598 MGI:MGI:1889907|PMID:11051546 ECO:0000315 MGI:MGI:1859962  2009-07-07 MGI BFO:0000066(EMAPA:36566),RO:0012003(CL:0000066) creation-date=2009-07-07|modification-date=2009-07-07|comment=anatomy mammary gland alveolus ; MA:0002760|comment=cell type epithelial cell ; CL:0000066|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2009-07-07" .
+
+_:t438452 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/e34a8c11-d429-4598-82fa-0262b63671f6> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002213> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/70953549-c4ea-4cab-b3a1-30b5f2443967> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/af610518-2fc7-4a3a-b70e-e366a55a1c03> ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0051897 MGI:MGI:1889907|PMID:11051546 ECO:0000315 MGI:MGI:1859962  2009-07-07 MGI GOREL:0001004(CL:0000066),GOREL:0001004(EMAPA:17760) creation-date=2009-07-07|modification-date=2009-07-07|comment=anatomy mammary gland epithelium ; MA:0000792|comment=cell type epithelial cell ; CL:0000066|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2009-07-07" .
+
+_:t438453 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/d1a35638-9490-4070-8a14-1672acd065d6> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002418> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/a2ae45c6-936e-449c-86e9-4be125d9fcce> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/ba1a0c31-0eaf-43cd-82cb-5303af1cb457> ;
+	<http://purl.org/dc/terms/created> "2000-07-06" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0009887 MGI:MGI:1329208|PMID:9950424 ECO:0000315 MGI:MGI:1859962  2000-07-06 MGI  creation-date=2000-07-06|modification-date=2000-07-06|contributor-id=GOC:tc" ;
+	<http://purl.org/dc/elements/1.1/contributor> "GOC:tc" ;
+	<http://purl.org/dc/elements/1.1/date> "2000-07-06" .
+
+_:t438454 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/4c632c01-9ea4-4d7a-a075-42d64872620f> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002213> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/70953549-c4ea-4cab-b3a1-30b5f2443967> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/02dc2866-9e33-4e1f-a5bc-53f5192066dc> ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0051897 MGI:MGI:1889907|PMID:11051546 ECO:0000315 MGI:MGI:1859962  2009-07-07 MGI GOREL:0001004(CL:0000066),GOREL:0001004(EMAPA:17760) creation-date=2009-07-07|modification-date=2009-07-07|comment=anatomy mammary gland epithelium ; MA:0000792|comment=cell type epithelial cell ; CL:0000066|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2009-07-07" .
+
+_:t438455 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/65975a29-2858-4db8-8140-c4315f69d3b2> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000066> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/8b23580a-252b-463b-bc29-4f606bdc66c1> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/7179f5b4-ea4b-4693-9499-213516e26c94> ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0033598 MGI:MGI:1889907|PMID:11051546 ECO:0000315 MGI:MGI:1859962  2009-07-07 MGI BFO:0000066(EMAPA:36566),RO:0012003(CL:0000066) creation-date=2009-07-07|modification-date=2009-07-07|comment=anatomy mammary gland alveolus ; MA:0002760|comment=cell type epithelial cell ; CL:0000066|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2009-07-07" .
+
+_:t438456 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/b74c7fb0-c46e-4ce0-a927-756679ee9319> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0012003> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/8b23580a-252b-463b-bc29-4f606bdc66c1> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/44d57ec2-7107-4066-9535-90b4a7a83d37> ;
+	<http://purl.org/dc/terms/created> "2009-07-07" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0033598 MGI:MGI:1889907|PMID:11051546 ECO:0000315 MGI:MGI:1859962  2009-07-07 MGI BFO:0000066(EMAPA:36566),RO:0012003(CL:0000066) creation-date=2009-07-07|modification-date=2009-07-07|comment=anatomy mammary gland alveolus ; MA:0002760|comment=cell type epithelial cell ; CL:0000066|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2009-07-07" .
+
+_:t438457 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/cccdadf9-9e0c-4ed2-bc47-7b513781a254> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/8c729218-bb3b-454e-82b6-ffd3261830b5> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/188e0f9b-862a-4615-aa32-1f8732f0d4c3> ;
+	<http://purl.org/dc/terms/created> "2003-09-12" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0045453 MGI:MGI:2448204|PMID:12490655 ECO:0000314   2003-09-12 MGI  creation-date=2003-09-12|modification-date=2003-09-12|contributor-id=https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2003-09-12" .
+
+_:t438458 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/4d3d8f73-bb9d-4436-bbc1-2e51e432e42a> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002418> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/8c729218-bb3b-454e-82b6-ffd3261830b5> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/36ae595b-adac-4de3-a4dc-66297e38cad3> ;
+	<http://purl.org/dc/terms/created> "2003-09-12" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0045453 MGI:MGI:2448204|PMID:12490655 ECO:0000314   2003-09-12 MGI  creation-date=2003-09-12|modification-date=2003-09-12|contributor-id=https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2003-09-12" .
+
+_:t438459 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/8f902b94-01c0-4334-8b56-affe62f529cd> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/8db6af9d-aef9-48b7-9ae3-622ef13b91c6> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/093519c2-8bb6-4414-9b4b-bf79d479e2d1> ;
+	<http://purl.org/dc/terms/created> "2018-02-22" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0030316 MGI:MGI:3836131|PMID:17442941 ECO:0000314   2018-02-22 MGI BFO:0000066(CL:0002476) creation-date=2018-02-22|modification-date=2018-02-22|contributor-id=https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-02-22" .
+
+_:t438460 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/54459d87-38a3-41a2-93c5-1aafb89d62b2> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002418> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/8db6af9d-aef9-48b7-9ae3-622ef13b91c6> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/f0a5d328-3e34-4bab-a1ff-0f216ae08e56> ;
+	<http://purl.org/dc/terms/created> "2018-02-22" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0030316 MGI:MGI:3836131|PMID:17442941 ECO:0000314   2018-02-22 MGI BFO:0000066(CL:0002476) creation-date=2018-02-22|modification-date=2018-02-22|contributor-id=https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-02-22" .
+
+_:t438461 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/03552651-4591-4f6e-87c6-c3d94b89c2a9> , <http://model.geneontology.org/MGI_MGI_1100089/25a94ce7-5d06-4275-a9e8-12ce2e05ac32> , <http://model.geneontology.org/MGI_MGI_1100089/460c6261-9afa-4ffd-82c1-4a605f5cbb45> , <http://model.geneontology.org/MGI_MGI_1100089/6922fbbc-e14b-49a4-a3fc-96a26b3614ae> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/82f0b431-4d2f-44d5-bbe6-53ee7a70c43c> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/c0beb774-354a-4781-b5b2-2cf27483011a> ;
+	<http://purl.org/dc/terms/created> "2005-05-06" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0045672 MGI:MGI:3528531|PMID:15657444 ECO:0000314   2005-05-06 MGI  creation-date=2005-05-06|modification-date=2005-05-06|contributor-id=https://orcid.org/0000-0002-9796-7693" , "MGI:MGI:1100089  RO:0002264 GO:0045672 MGI:MGI:5295788|PMID:21982707 ECO:0000316 MGI:MGI:102469|MGI:MGI:2158925  2013-01-09 MGI  creation-date=2013-01-09|modification-date=2013-01-09|contributor-id=https://orcid.org/0000-0001-7476-6306" , "MGI:MGI:1100089  RO:0002264 GO:0045672 MGI:MGI:4849322|PMID:21048959 ECO:0000316 MGI:MGI:1339753  2015-10-30 MGI  creation-date=2015-10-30|modification-date=2015-10-30|comment=anatomy bone marrow ; MA:0000134|contributor-id=https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" , "https://orcid.org/0000-0003-3394-9805" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2015-10-30" .
+
+_:t438462 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/18ebc54a-5cb5-4232-9b66-ae77098e6808> , <http://model.geneontology.org/MGI_MGI_1100089/61a1eb2b-1233-48cf-ab7b-4ea8aa4cff74> , <http://model.geneontology.org/MGI_MGI_1100089/a891d466-9b1e-4e19-b69e-936541d2769a> , <http://model.geneontology.org/MGI_MGI_1100089/df353207-b046-4bf5-9c10-54bdc50297ee> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002418> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/82f0b431-4d2f-44d5-bbe6-53ee7a70c43c> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/3bad60ec-4a12-4f38-b1e6-2780c266fa60> ;
+	<http://purl.org/dc/terms/created> "2005-05-06" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0045672 MGI:MGI:3528531|PMID:15657444 ECO:0000314   2005-05-06 MGI  creation-date=2005-05-06|modification-date=2005-05-06|contributor-id=https://orcid.org/0000-0002-9796-7693" , "MGI:MGI:1100089  RO:0002264 GO:0045672 MGI:MGI:5295788|PMID:21982707 ECO:0000316 MGI:MGI:102469|MGI:MGI:2158925  2013-01-09 MGI  creation-date=2013-01-09|modification-date=2013-01-09|contributor-id=https://orcid.org/0000-0001-7476-6306" , "MGI:MGI:1100089  RO:0002264 GO:0045672 MGI:MGI:4849322|PMID:21048959 ECO:0000316 MGI:MGI:1339753  2015-10-30 MGI  creation-date=2015-10-30|modification-date=2015-10-30|comment=anatomy bone marrow ; MA:0000134|contributor-id=https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" , "https://orcid.org/0000-0003-3394-9805" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2015-10-30" .
+
+_:t438463 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/11929829-8f47-4966-bf3e-c3639b59086e> , <http://model.geneontology.org/MGI_MGI_1100089/be2e0558-1e6a-47ba-a213-ba051fac4424> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002315> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/85b039b9-df79-4b01-bca4-d3cfc681a3be> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/4ddc75d5-48d4-4520-96fb-c8b4ce99cc5f> ;
+	<http://purl.org/dc/terms/created> "2005-12-23" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0045672 MGI:MGI:3689489|PMID:17053831 ECO:0000316 MGI:MGI:1339753  2007-02-12 MGI GOREL:0001010(CL:0000092) creation-date=2007-02-12|modification-date=2007-02-12|comment=cell type primary cell line cell ; CL:0000001 osteoclast ; CL:0000092|contributor-id=https://orcid.org/0000-0001-7476-6306" , "MGI:MGI:1100089  RO:0002264 GO:0045672 MGI:MGI:3575849|PMID:15724149 ECO:0000314   2005-12-23 MGI GOREL:0001010(CL:0000092) creation-date=2005-12-23|modification-date=2005-12-23|comment=cell type osteoclast ; CL:0000092 primary_cell_line ; CL:0000001|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2007-02-12" .
+
+_:t438464 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/c97fc108-04a9-4db5-a573-6427d4ecfa53> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/a7a0b7c8-a408-4309-abdd-b986dc1b01e3> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/c33cc31d-4eab-457f-a4b4-e5184f8f1925> ;
+	<http://purl.org/dc/terms/created> "2004-04-30" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0030316 MGI:MGI:2682475|PMID:14662855 ECO:0000314   2004-04-30 MGI  creation-date=2004-04-30|modification-date=2004-04-30|contributor-id=https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2004-04-30" .
+
+_:t438465 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/1237bf34-6cac-4688-91ab-3da99857003d> , <http://model.geneontology.org/MGI_MGI_1100089/99750d1e-6561-4468-8502-2c1a5c10c1eb> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/9bdcc1bb-511b-4b96-a434-e3facbce2429> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/380a5f4b-0329-46ae-87d7-17a1bfae7e1d> ;
+	<http://purl.org/dc/terms/created> "2005-03-17" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0030316 MGI:MGI:3525391|PMID:15485831 ECO:0000316 MGI:MGI:104798|MGI:MGI:99484  2005-03-17 MGI BFO:0000066(EMAPA:16846),RO:0002315(CL:0000092) creation-date=2005-03-17|modification-date=2005-03-17|comment=anatomy TS26\\ liver; EMAP:12229|comment=cell type osteoclast ; CL:0000092 primary_cell_line ; CL:0000001|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2005-03-17" .
+
+_:t438466 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/b2f4fdb9-e313-4d2e-80d6-d42204de492f> , <http://model.geneontology.org/MGI_MGI_1100089/b3389cb3-cec3-4e05-b665-360b7fc84de2> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002418> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/9bdcc1bb-511b-4b96-a434-e3facbce2429> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/54dbca03-f4e9-4457-b2fd-2c8f2d92e9c2> ;
+	<http://purl.org/dc/terms/created> "2005-03-17" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0030316 MGI:MGI:3525391|PMID:15485831 ECO:0000316 MGI:MGI:104798|MGI:MGI:99484  2005-03-17 MGI BFO:0000066(EMAPA:16846),RO:0002315(CL:0000092) creation-date=2005-03-17|modification-date=2005-03-17|comment=anatomy TS26\\ liver; EMAP:12229|comment=cell type osteoclast ; CL:0000092 primary_cell_line ; CL:0000001|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2005-03-17" .
+
+_:t438467 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/8e64b707-88f5-4d57-9932-eff43dab9517> , <http://model.geneontology.org/MGI_MGI_1100089/eb2628fa-65fd-490f-85df-7d08723a60db> , <http://model.geneontology.org/MGI_MGI_1100089/f5e4516b-e7a0-4080-8f5d-b28d6318950c> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/9bf2332e-2fc9-4f1f-8cdb-81190e156da9> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/c6579ca4-ef10-48c0-af12-c808be709bba> ;
+	<http://purl.org/dc/terms/created> "2014-03-27" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:2001206 MGI:MGI:3785147|PMID:18269914 ECO:0000314   2015-10-28 MGI  creation-date=2015-10-28|modification-date=2015-10-28|contributor-id=https://orcid.org/0000-0002-9796-7693" , "MGI:MGI:1100089  RO:0002264 GO:2001206 MGI:MGI:5489769|PMID:22437732 ECO:0000314   2015-10-21 MGI  creation-date=2015-10-21|modification-date=2015-10-21|contributor-id=https://orcid.org/0000-0002-9796-7693" , "MGI:MGI:1100089  RO:0002264 GO:2001206 MGI:MGI:5522615|PMID:23980096 ECO:0000314   2014-03-27 MGI  creation-date=2014-03-27|modification-date=2014-03-27|contributor-id=https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" , "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2015-10-28" .
+
+_:t438468 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/5462f6bb-b633-4a6a-ba73-d8328de17585> , <http://model.geneontology.org/MGI_MGI_1100089/7c03dfd6-b031-4709-a8df-3176d6dda57b> , <http://model.geneontology.org/MGI_MGI_1100089/8e7a4c80-7ddd-4832-b9a8-6bae41683645> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002418> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/9bf2332e-2fc9-4f1f-8cdb-81190e156da9> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/4aac0fab-0e4b-4972-909f-2d982cb1844e> ;
+	<http://purl.org/dc/terms/created> "2014-03-27" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:2001206 MGI:MGI:3785147|PMID:18269914 ECO:0000314   2015-10-28 MGI  creation-date=2015-10-28|modification-date=2015-10-28|contributor-id=https://orcid.org/0000-0002-9796-7693" , "MGI:MGI:1100089  RO:0002264 GO:2001206 MGI:MGI:5489769|PMID:22437732 ECO:0000314   2015-10-21 MGI  creation-date=2015-10-21|modification-date=2015-10-21|contributor-id=https://orcid.org/0000-0002-9796-7693" , "MGI:MGI:1100089  RO:0002264 GO:2001206 MGI:MGI:5522615|PMID:23980096 ECO:0000314   2014-03-27 MGI  creation-date=2014-03-27|modification-date=2014-03-27|contributor-id=https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" , "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2015-10-28" .
+
+_:t438469 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/06f0ebb7-e3cc-4f91-854e-bff4a162dd91> , <http://model.geneontology.org/MGI_MGI_1100089/6959e026-b579-4255-96d4-02ec89af1981> , <http://model.geneontology.org/MGI_MGI_1100089/ba425eb8-0952-4b2e-b4ea-d7d77ef9606d> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/9e6ad43c-f097-4f59-928b-36e90d0c362b> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/ef580431-649a-4d41-bf2c-7d5e86d48cd2> ;
+	<http://purl.org/dc/terms/created> "2015-10-21" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0071847 MGI:MGI:3785147|PMID:18269914 ECO:0000314   2015-10-28 MGI  creation-date=2015-10-28|modification-date=2015-10-28|contributor-id=https://orcid.org/0000-0002-9796-7693" , "MGI:MGI:1100089  RO:0002264 GO:0071847 MGI:MGI:3836131|PMID:17442941 ECO:0000314   2018-02-22 MGI  creation-date=2018-02-22|modification-date=2018-02-22|contributor-id=https://orcid.org/0000-0002-9796-7693" , "MGI:MGI:1100089  RO:0002264 GO:0071847 MGI:MGI:5489769|PMID:22437732 ECO:0000314   2015-10-21 MGI  creation-date=2015-10-21|modification-date=2015-10-21|contributor-id=https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-02-22" .
+
+_:t438470 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/36a54bd5-c49e-4bd2-b32f-0f3b9ff5d2b7> , <http://model.geneontology.org/MGI_MGI_1100089/6df7df7f-ebca-4bab-8bfd-e2f5ec9634a0> , <http://model.geneontology.org/MGI_MGI_1100089/d4886d11-549c-4207-bb36-fbfa7aa1e1d3> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002418> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/9e6ad43c-f097-4f59-928b-36e90d0c362b> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/23cd23c1-33a3-4fc2-a380-131cc6690ec0> ;
+	<http://purl.org/dc/terms/created> "2015-10-21" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0071847 MGI:MGI:3785147|PMID:18269914 ECO:0000314   2015-10-28 MGI  creation-date=2015-10-28|modification-date=2015-10-28|contributor-id=https://orcid.org/0000-0002-9796-7693" , "MGI:MGI:1100089  RO:0002264 GO:0071847 MGI:MGI:3836131|PMID:17442941 ECO:0000314   2018-02-22 MGI  creation-date=2018-02-22|modification-date=2018-02-22|contributor-id=https://orcid.org/0000-0002-9796-7693" , "MGI:MGI:1100089  RO:0002264 GO:0071847 MGI:MGI:5489769|PMID:22437732 ECO:0000314   2015-10-21 MGI  creation-date=2015-10-21|modification-date=2015-10-21|contributor-id=https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2018-02-22" .
+
+_:t438471 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/8555e920-3990-4442-bde7-fb5bb8b4f9cd> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002418> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/a7a0b7c8-a408-4309-abdd-b986dc1b01e3> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/60fcf2b3-8aa2-47e8-81a9-203134ace208> ;
+	<http://purl.org/dc/terms/created> "2004-04-30" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0030316 MGI:MGI:2682475|PMID:14662855 ECO:0000314   2004-04-30 MGI  creation-date=2004-04-30|modification-date=2004-04-30|contributor-id=https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0002-9796-7693" ;
+	<http://purl.org/dc/elements/1.1/date> "2004-04-30" .
+
+_:t438472 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1100089/32cd7c73-31ba-439d-8d4c-2657daec68d7> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1100089/a8f58802-da21-452d-97e9-1f85b764c0e8> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1100089/afcd09f8-751d-4f7e-bc56-9fcedb3782ab> ;
+	<http://purl.org/dc/terms/created> "2015-03-19" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1100089  RO:0002264 GO:0038001 MGI:MGI:5576858|PMID:24190884 ECO:0000314   2015-03-19 MGI  creation-date=2015-03-19|modification-date=2015-03-19|contributor-id=https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2015-03-19" .

--- a/tests/test_gocam_ttl.py
+++ b/tests/test_gocam_ttl.py
@@ -28,3 +28,86 @@ def test_gocam_ttl():
     gocam_graph = builder.parse_ttl("resources/test/SYNGO_5371.ttl")  # SynGO
     assert len(gocam_graph.standard_annotations) == 1
     assert len(gocam_graph.non_standard_annotations) == 0
+
+    gocam_graph = builder.parse_ttl("resources/test/MGI_MGI_1100089.ttl")  # Tnfsf11
+    test_individual = rdflib.term.URIRef(
+        'http://model.geneontology.org/MGI_MGI_1100089/95094c4f-335a-4e08-9840-b42760a96357')
+    std_annot = gocam_graph.get_standard_annotation_by_individual(test_individual)
+    assert len(std_annot.edges) == 3
+    assert len(gocam_graph.standard_annotations) == 29
+    assert len(gocam_graph.non_standard_annotations) == 0
+
+    gocam_graph = builder.parse_ttl("resources/test/61452e3d00000323.ttl")  # MAL loci in Saccharomyces
+    test_individual = rdflib.term.URIRef('http://model.geneontology.org/61452e3d00000323/61452e3d00000330')
+    std_annot = gocam_graph.get_standard_annotation_by_individual(test_individual)
+    assert len(std_annot.edges) == 3
+    assert len(gocam_graph.standard_annotations) == 10
+    assert len(gocam_graph.non_standard_annotations) == 0
+    gocam_graph.split_evidence_and_write_ttl("target/61452e3d00000323.ttl")
+
+
+def test_multi_edge_evidence_grouping():
+    """
+    Test that evidence with identical metadata across multiple edges
+    is properly grouped when splitting.
+
+    Issue #6: Evidence individuals that have identical data on the same
+    standard annotation subgraph but on different edges need to be grouped
+    together so that newly created multi-edge subgraphs retain the correct
+    group of evidence individuals.
+    """
+    builder = GoCamGraphBuilder(ontology_file)
+    gocam_graph = builder.parse_ttl("resources/test/MGI_MGI_1100089.ttl")
+
+    # Find the standard annotation with the multi-edge multi-evidence issue
+    # This annotation has source individual ad099715-8779-4315-b3cd-77a1c25a6177
+    test_individual = rdflib.term.URIRef(
+        'http://model.geneontology.org/MGI_MGI_1100089/ad099715-8779-4315-b3cd-77a1c25a6177')
+    std_annot = gocam_graph.get_standard_annotation_by_individual(test_individual)
+
+    # Should have 2 edges (enabled_by and causally_upstream_of)
+    assert len(std_annot.edges) == 2
+
+    # Test evidence grouping
+    evidence_groups = gocam_graph.group_evidence_by_metadata(std_annot)
+
+    # Should have 2 evidence groups (one for 2003-09-12 evidence, one for 2013-08-27)
+    assert len(evidence_groups) == 2
+
+    # Each group should have evidence from both edges
+    for group_index, group_edges in evidence_groups.items():
+        assert len(group_edges) == 2, f"Group {group_index} should have evidence from both edges"
+        # Each edge in the group should have exactly 1 evidence
+        for edge_id, evidence_uris in group_edges.items():
+            assert len(evidence_uris) == 1, f"Each edge should have 1 evidence in group {group_index}"
+
+    # Now split and verify the output
+    gocam_graph.split_evidence_and_write_ttl("target/MGI_MGI_1100089_split.ttl")
+
+    # Reload the split model
+    gocam_graph_split = builder.parse_ttl("target/MGI_MGI_1100089_split.ttl")
+
+    # After splitting, we should have more annotations (2 annotations per original multi-evidence annotation)
+    # Original has 29 standard annotations, at least one with multi-evidence across 2 edges
+    # So we expect at least 30 standard annotations after splitting
+    assert len(gocam_graph_split.standard_annotations) >= 30
+
+    # Find the split annotations - look for the original individual and the -2 suffix version
+    original_annot = gocam_graph_split.get_standard_annotation_by_individual(test_individual)
+    split_individual = rdflib.term.URIRef(str(test_individual) + "-2")
+    split_annot = gocam_graph_split.get_standard_annotation_by_individual(split_individual)
+
+    # Both should exist
+    assert original_annot is not None, "Original annotation should exist"
+    assert split_annot is not None, "Split annotation with -2 suffix should exist"
+
+    # Both should have 2 edges (same structure, different evidence)
+    assert len(original_annot.edges) == 2
+    assert len(split_annot.edges) == 2
+
+    # Each edge in each annotation should have exactly 1 evidence
+    for edge in original_annot.edges.values():
+        assert len(edge.evidence_uris) == 1, "Original annotation edges should have 1 evidence each"
+
+    for edge in split_annot.edges.values():
+        assert len(edge.evidence_uris) == 1, "Split annotation edges should have 1 evidence each"


### PR DESCRIPTION
For #6.

For all edges of a standard annotation subgraph, evidence individuals with identical properties on different edges are grouped together and split out together.