### PR TITLE
Multi-edge standard annotations must have same evidence pattern

### DIFF
--- a/resources/test/MGI_MGI_1927246.ttl
+++ b/resources/test/MGI_MGI_1927246.ttl
@@ -1,0 +1,314 @@
+
+<http://model.geneontology.org/MGI_MGI_1927246> a <http://www.w3.org/2002/07/owl#Ontology> .
+
+<http://geneontology.org/lego/evidence> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://geneontology.org/lego/hint/layout/x> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://geneontology.org/lego/hint/layout/y> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/RO_0002333> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.obolibrary.org/obo/RO_0002418> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.org/pav/providedBy> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/BFO_0000050> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.obolibrary.org/obo/RO_0001025> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.org/dc/terms/created> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.org/dc/terms/dateAccepted> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/MGI_MGI_1927246> <http://geneontology.org/lego/modelstate> "production" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://www.w3.org/2002/07/owl#versionIRI> <http://model.geneontology.org/MGI_MGI_1927246> ;
+	<https://w3id.org/biolink/vocab/in_taxon> <http://purl.obolibrary.org/obo/NCBITaxon_10090> ;
+	<http://purl.org/dc/terms/created> "2005-08-15" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Ontology> ;
+	<http://purl.org/dc/elements/1.1/title> "Zfp326 (MGI:MGI:1927246)" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/date> "2007-01-24" .
+
+<http://model.geneontology.org/MGI_MGI_1927246/127b6127-8032-4750-b9a1-84a372246d18> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2005-08-15" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "evidence IB following cell fractionation" , "cell type permanent cell line ; CLO:0000019 fibroblast ; CL:0000057 ATCC:CRL-1658 (NIH/3T3  mouse)" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-08-15" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:9809746" .
+
+<http://model.geneontology.org/MGI_MGI_1927246/30e06768-6edc-4198-b8ac-74a425571be3> <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1927246/5a290c0d-58f9-4a7e-9b02-49d9dc223c49> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2005-08-15" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003677> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-08-15" .
+
+<http://model.geneontology.org/MGI_MGI_1927246/35f7997e-0ff0-42a4-9f8e-de6203f53331> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2007-01-24" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0045893> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/date> "2007-01-24" .
+
+<http://model.geneontology.org/MGI_MGI_1927246/3f54b430-ad9c-44a7-828f-1f83aba76c83> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2005-08-15" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1927246> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-08-15" .
+
+<http://model.geneontology.org/MGI_MGI_1927246/49867aa7-ad4d-4902-b542-da74bf9bf366> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.obolibrary.org/obo/RO_0001025> <http://model.geneontology.org/MGI_MGI_1927246/a2d70b72-b5ee-4f60-9f2c-1e52c1ad5196> ;
+	<http://purl.org/dc/terms/created> "2005-08-15" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1927246> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-08-18" .
+
+<http://model.geneontology.org/MGI_MGI_1927246/5a290c0d-58f9-4a7e-9b02-49d9dc223c49> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2005-08-15" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1927246> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-08-15" .
+
+<http://model.geneontology.org/MGI_MGI_1927246/6375f58c-3ddb-4fd2-8483-75c83afaa117> <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1927246/6a430571-2224-46a3-9a82-63ba9fc22916> ;
+	<http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_1927246/35f7997e-0ff0-42a4-9f8e-de6203f53331> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2007-01-24" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/date> "2007-01-24" .
+
+<http://model.geneontology.org/MGI_MGI_1927246/63878ec6-e449-4c0a-9843-59e07936c57f> <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1927246/3f54b430-ad9c-44a7-828f-1f83aba76c83> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2005-08-15" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008270> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-08-15" .
+
+<http://model.geneontology.org/MGI_MGI_1927246/6a430571-2224-46a3-9a82-63ba9fc22916> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2007-01-24" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1927246> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/date> "2007-01-24" .
+
+<http://model.geneontology.org/MGI_MGI_1927246/7c5649e1-c8a9-4465-ba42-91711ea39204> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.obolibrary.org/obo/RO_0001025> <http://model.geneontology.org/MGI_MGI_1927246/a6965fdf-6bdc-4776-9613-207b1633f73b> ;
+	<http://purl.org/dc/terms/created> "2005-08-15" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1927246> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-08-15" .
+
+<http://model.geneontology.org/MGI_MGI_1927246/96479323-72ff-4c2e-82f9-184c31855e20> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2007-01-24" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "cell type permanent cell line ; CLO:0000019 COS-7 ; ATCC:CRL-1651" , "evidence CAT assay following transfection of reporter construct" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/date> "2007-01-24" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:10798446" .
+
+<http://model.geneontology.org/MGI_MGI_1927246/a2d70b72-b5ee-4f60-9f2c-1e52c1ad5196> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/MGI_MGI_1927246/a2f2216c-0cf5-4436-8a75-b3aa41974936> ;
+	<http://purl.org/dc/terms/created> "2005-08-15" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005634> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-08-18" .
+
+<http://model.geneontology.org/MGI_MGI_1927246/a2f2216c-0cf5-4436-8a75-b3aa41974936> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2005-08-15" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CL_0000057> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-08-18" .
+
+<http://model.geneontology.org/MGI_MGI_1927246/a6965fdf-6bdc-4776-9613-207b1633f73b> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/MGI_MGI_1927246/cc7e6931-54f8-4a65-8fac-7cabc9b97008> ;
+	<http://purl.org/dc/terms/created> "2005-08-15" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0016363> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-08-15" .
+
+<http://model.geneontology.org/MGI_MGI_1927246/ac27bae4-bb43-4bf0-bab8-da946e73881d> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2005-08-15" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "cell type permanent cell line ; CLO:0000019 fibroblast ; CL:0000057 ATCC:CRL-1658 (NIH/3T3  mouse  transfected)" , "evidence microscopy of GFP-tagged protein" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-08-15" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:9809746" .
+
+<http://model.geneontology.org/MGI_MGI_1927246/b4affbfb-f2b7-4903-92b0-6e44e08359c1> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2005-08-15" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "evidence 32P-labeled DNA binding assay (in vitro) in presence of zinc chelating agent" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-08-15" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:9809746" .
+
+<http://model.geneontology.org/MGI_MGI_1927246/b7500cbd-4cc4-42e2-ba96-e6181706b587> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2005-08-18" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "evidence IF" , "cell type permanent cell line ; CLO:0000019 fibroblast ; CL:0000057 ATCC:CRL-1658 (NIH/3T3  mouse)" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-08-18" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:10798446" .
+
+<http://model.geneontology.org/MGI_MGI_1927246/ba6ddda0-7325-47a6-a246-3ebbfd8fa8c8> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2007-01-24" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "cell type permanent cell line ; CLO:0000019 COS-7 ; ATCC:CRL-1651" , "evidence CAT assay following transfection of reporter construct" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/date> "2007-01-24" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:10798446" .
+
+<http://model.geneontology.org/MGI_MGI_1927246/c3c705e1-3a93-4fef-8332-70c1e9041a17> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2005-08-15" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "evidence IB following cell fractionation" , "cell type permanent cell line ; CLO:0000019 fibroblast ; CL:0000057 ATCC:CRL-1658 (NIH/3T3  mouse)" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-08-15" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:9809746" .
+
+<http://model.geneontology.org/MGI_MGI_1927246/cc7e6931-54f8-4a65-8fac-7cabc9b97008> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2005-08-15" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CL_0000057> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-08-15" .
+
+<http://model.geneontology.org/MGI_MGI_1927246/d4098732-90c1-45be-aa79-528c395cafdf> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2005-08-15" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "cell type permanent cell line ; CLO:0000019 fibroblast ; CL:0000057 ATCC:CRL-1658 (NIH/3T3  mouse  transfected)" , "evidence microscopy of GFP-tagged protein" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-08-15" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:9809746" .
+
+<http://model.geneontology.org/MGI_MGI_1927246/e09722c7-348f-42df-b14e-704c55ec023b> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2005-08-18" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "evidence IF" , "cell type permanent cell line ; CLO:0000019 fibroblast ; CL:0000057 ATCC:CRL-1658 (NIH/3T3  mouse)" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-08-18" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:10798446" .
+
+<http://model.geneontology.org/MGI_MGI_1927246/f0f5eb36-a410-4f72-b5ed-3b99c7d46901> <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://purl.org/dc/terms/created> "2005-08-15" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "evidence 32P-labeled DNA binding assay (in vitro)" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-08-15" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:9809746" .
+
+<http://purl.org/dc/elements/1.1/contributor> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.org/dc/elements/1.1/date> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.org/dc/elements/1.1/source> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+_:t1336634 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1927246/127b6127-8032-4750-b9a1-84a372246d18> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000050> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1927246/a6965fdf-6bdc-4776-9613-207b1633f73b> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1927246/cc7e6931-54f8-4a65-8fac-7cabc9b97008> ;
+	<http://purl.org/dc/terms/created> "2005-08-15" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1927246  RO:0001025 GO:0016363 MGI:MGI:1309638|PMID:9809746 ECO:0000314   2005-08-15 MGI BFO:0000050(CL:0000057) creation-date=2005-08-15|modification-date=2005-08-15|comment=cell type permanent cell line ; CLO:0000019 fibroblast ; CL:0000057 ATCC:CRL-1658 (NIH/3T3  mouse)|comment=evidence IB following cell fractionation|contributor-id=https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-08-15" .
+
+_:t1336635 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1927246/c3c705e1-3a93-4fef-8332-70c1e9041a17> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0001025> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1927246/7c5649e1-c8a9-4465-ba42-91711ea39204> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1927246/a6965fdf-6bdc-4776-9613-207b1633f73b> ;
+	<http://purl.org/dc/terms/created> "2005-08-15" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1927246  RO:0001025 GO:0016363 MGI:MGI:1309638|PMID:9809746 ECO:0000314   2005-08-15 MGI BFO:0000050(CL:0000057) creation-date=2005-08-15|modification-date=2005-08-15|comment=cell type permanent cell line ; CLO:0000019 fibroblast ; CL:0000057 ATCC:CRL-1658 (NIH/3T3  mouse)|comment=evidence IB following cell fractionation|contributor-id=https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-08-15" .
+
+_:t1336636 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1927246/ac27bae4-bb43-4bf0-bab8-da946e73881d> , <http://model.geneontology.org/MGI_MGI_1927246/b7500cbd-4cc4-42e2-ba96-e6181706b587> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000050> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1927246/a2d70b72-b5ee-4f60-9f2c-1e52c1ad5196> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1927246/a2f2216c-0cf5-4436-8a75-b3aa41974936> ;
+	<http://purl.org/dc/terms/created> "2005-08-15" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1927246  RO:0001025 GO:0005634 MGI:MGI:1309638|PMID:9809746 ECO:0000314   2005-08-15 MGI BFO:0000050(CL:0000057) creation-date=2005-08-15|modification-date=2005-08-15|comment=cell type permanent cell line ; CLO:0000019 fibroblast ; CL:0000057 ATCC:CRL-1658 (NIH/3T3  mouse  transfected)|comment=evidence microscopy of GFP-tagged protein|contributor-id=https://orcid.org/0000-0001-9990-8331" , "MGI:MGI:1927246  RO:0001025 GO:0005634 MGI:MGI:1355426|PMID:10798446 ECO:0000314   2005-08-18 MGI BFO:0000050(CL:0000057) creation-date=2005-08-18|modification-date=2005-08-18|comment=cell type permanent cell line ; CLO:0000019 fibroblast ; CL:0000057 ATCC:CRL-1658 (NIH/3T3  mouse)|comment=evidence IF|contributor-id=https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-08-18" .
+
+_:t1336637 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1927246/b4affbfb-f2b7-4903-92b0-6e44e08359c1> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1927246/63878ec6-e449-4c0a-9843-59e07936c57f> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1927246/3f54b430-ad9c-44a7-828f-1f83aba76c83> ;
+	<http://purl.org/dc/terms/created> "2005-08-15" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1927246  RO:0002327 GO:0008270 MGI:MGI:1309638|PMID:9809746 ECO:0000314   2005-08-15 MGI  creation-date=2005-08-15|modification-date=2005-08-15|comment=evidence 32P-labeled DNA binding assay (in vitro) in presence of zinc chelating agent|contributor-id=https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-08-15" .
+
+_:t1336638 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1927246/d4098732-90c1-45be-aa79-528c395cafdf> , <http://model.geneontology.org/MGI_MGI_1927246/e09722c7-348f-42df-b14e-704c55ec023b> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0001025> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1927246/49867aa7-ad4d-4902-b542-da74bf9bf366> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1927246/a2d70b72-b5ee-4f60-9f2c-1e52c1ad5196> ;
+	<http://purl.org/dc/terms/created> "2005-08-15" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1927246  RO:0001025 GO:0005634 MGI:MGI:1309638|PMID:9809746 ECO:0000314   2005-08-15 MGI BFO:0000050(CL:0000057) creation-date=2005-08-15|modification-date=2005-08-15|comment=cell type permanent cell line ; CLO:0000019 fibroblast ; CL:0000057 ATCC:CRL-1658 (NIH/3T3  mouse  transfected)|comment=evidence microscopy of GFP-tagged protein|contributor-id=https://orcid.org/0000-0001-9990-8331" , "MGI:MGI:1927246  RO:0001025 GO:0005634 MGI:MGI:1355426|PMID:10798446 ECO:0000314   2005-08-18 MGI BFO:0000050(CL:0000057) creation-date=2005-08-18|modification-date=2005-08-18|comment=cell type permanent cell line ; CLO:0000019 fibroblast ; CL:0000057 ATCC:CRL-1658 (NIH/3T3  mouse)|comment=evidence IF|contributor-id=https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-08-18" .
+
+_:t1336639 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1927246/f0f5eb36-a410-4f72-b5ed-3b99c7d46901> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1927246/30e06768-6edc-4198-b8ac-74a425571be3> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1927246/5a290c0d-58f9-4a7e-9b02-49d9dc223c49> ;
+	<http://purl.org/dc/terms/created> "2005-08-15" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1927246  RO:0002327 GO:0003677 MGI:MGI:1309638|PMID:9809746 ECO:0000314   2005-08-15 MGI  creation-date=2005-08-15|modification-date=2005-08-15|comment=evidence 32P-labeled DNA binding assay (in vitro)|contributor-id=https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/date> "2005-08-15" .
+
+_:t1336640 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1927246/96479323-72ff-4c2e-82f9-184c31855e20> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002418> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1927246/6375f58c-3ddb-4fd2-8483-75c83afaa117> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1927246/35f7997e-0ff0-42a4-9f8e-de6203f53331> ;
+	<http://purl.org/dc/terms/created> "2007-01-24" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1927246  RO:0002264 GO:0045893 MGI:MGI:1355426|PMID:10798446 ECO:0000314   2007-01-24 MGI  creation-date=2007-01-24|modification-date=2007-01-24|comment=cell type permanent cell line ; CLO:0000019 COS-7 ; ATCC:CRL-1651|comment=evidence CAT assay following transfection of reporter construct|contributor-id=https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/date> "2007-01-24" .
+
+_:t1336641 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1927246/ba6ddda0-7325-47a6-a246-3ebbfd8fa8c8> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1927246/6375f58c-3ddb-4fd2-8483-75c83afaa117> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1927246/6a430571-2224-46a3-9a82-63ba9fc22916> ;
+	<http://purl.org/dc/terms/created> "2007-01-24" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1927246  RO:0002264 GO:0045893 MGI:MGI:1355426|PMID:10798446 ECO:0000314   2007-01-24 MGI  creation-date=2007-01-24|modification-date=2007-01-24|comment=cell type permanent cell line ; CLO:0000019 COS-7 ; ATCC:CRL-1651|comment=evidence CAT assay following transfection of reporter construct|contributor-id=https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-9990-8331" ;
+	<http://purl.org/dc/elements/1.1/date> "2007-01-24" .


### PR DESCRIPTION
For #5.

This ensures the evidence across an annotation's edges are manageable to unwind.

Also fixes a bug noticed where some extensions were not split out. Such as for Zfp326 [MGI_MGI_1927246](http://noctua.geneontology.org/editor/graph/gomodel:MGI_MGI_1927246?).
Before split:
<img width="998" height="147" alt="image" src="https://github.com/user-attachments/assets/417ab821-67b5-4ea2-a3f0-4f5318bab8e2" />
After split:
<img width="943" height="295" alt="image" src="https://github.com/user-attachments/assets/4fbae067-f746-4a07-8c4c-da4f17d74f38" />
