### PR TITLE
Update date on otherwise same evidence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,8 @@ python src/gocam_unwinder/gocam_ttl.py \
   --split-evidence \
   --output-dir output/ \
   --report-file report.tsv \
-  --criteria-fail-report failures.tsv
+  --criteria-fail-report failures.tsv \
+  --date-change-report date_changes.tsv
 ```
 
 ## Planning
@@ -271,7 +272,7 @@ The evidence splitting process now groups evidence by metadata to handle multi-e
 #### Evidence Metadata Grouping
 
 The `get_evidence_metadata()` method (lines 102-127) extracts a metadata signature from each evidence individual:
-- Collects values for predicates in `PREDICATES_TO_COPY` (type, contributor, date, created, dateAccepted, providedBy, comment)
+- Collects values for predicates in `PREDICATES_TO_COPY`, **excluding date predicates** (`dc:date`, `dcterms:created`, `dcterms:dateAccepted`) so that evidence differing only in dates can be grouped together (Issue #15)
 - Also includes `evidence-with` and `source` predicates
 - Returns a hashable tuple that uniquely identifies evidence with identical metadata
 
@@ -288,7 +289,8 @@ This ensures that evidence representing the same "evidence event" across differe
 The `split_evidence_and_write_ttl()` method (lines 180-255) implements the actual splitting:
 
 1. For each standard annotation, get evidence groups via `group_evidence_by_metadata()`
-2. For each evidence group:
+2. Update `dc:date` to the most recent value across all evidence in each group, but only when dates actually differ (Issue #15). Updates both evidence individuals and BNode axioms. Prints a report line for each update: `Date updated to {date} for {model_id} ({title})`. Uses `get_most_recent_date()` and `update_evidence_date()` helper methods. Collects per-edge date change records (with source_type, property_uri, target_type URIs) for reporting
+3. For each evidence group:
    - Group 0 (first): keeps original blank nodes and individuals, removes extra evidence
    - Groups 1+ (subsequent): creates new blank nodes with suffix "-2", "-3", etc.
    - Creates new individual URIs with same suffix for all edges in the group
@@ -299,6 +301,8 @@ The `split_evidence_and_write_ttl()` method (lines 180-255) implements the actua
 **Example:** If an annotation has 2 edges with evidence [A, B] and [C, D] respectively, where metadata(A) == metadata(C) and metadata(B) == metadata(D):
 - Group 0: Edge 1 with evidence A + Edge 2 with evidence C (original nodes)
 - Group 1: Edge 1 with evidence B + Edge 2 with evidence D (new nodes with "-2" suffix)
+
+The method returns a list of date change record dicts (with keys: model_id, title, original_date, new_date, source_type, property_uri, target_type) for edges where `dc:date` was updated. In `main()`, these records are resolved to human-readable labels via `term_label()` and written to a TSV file if `--date-change-report` is specified. Report columns: Model ID, Title, Original Date, New Date, Source, Predicate, Target.
 
 This maintains provenance while ensuring one-to-one edge-to-evidence relationships and correct evidence grouping across edges.
 
@@ -324,6 +328,10 @@ Tests use real GO-CAM model examples in `resources/test/`:
   - Without the filter, non-GO-CAM axiom edges (oboInOwl#id, rdfs:label) cause incorrect subgraph splitting
 - **67369e7600005491.ttl**: Mouse Hnf4aos model with a subgraph (causally_upstream_of_or_within -> GO:0006954 inflammatory response) where all 3 edges have no evidence
   - Used to test `edge_without_evidence` filter on an annotation with zero total evidence
+- **MGI_MGI_1101770.ttl**: Mouse Ring1 model with date-differing evidence across edges (Issue #15)
+  - enabled_by edge has evidence dated 2006-08-09, causally_upstream_of edge has evidence dated 2023-02-13
+  - Evidence is otherwise identical (same ECO, PMID, contributor) — only dates and dcterms:created presence differ
+  - Used to test date-tolerant evidence grouping and date update during splitting
 
 The test requires the GO ontology file at `target/go_20250601.json` (downloaded via Makefile). The MF-causal->MF test also requires `resources/test/ro_20250723.owl`.
 
@@ -364,3 +372,14 @@ The test requires the GO ontology file at `target/go_20250601.json` (downloaded 
 - `test_edge_without_evidence_all_edges_no_evidence()`: Tests all-no-evidence subgraph using model 67369e7600005491:
   - Verifies the GO:0006954 (inflammatory response) subgraph with 3 no-evidence edges is non-standard
   - All 3 no-evidence edges are flagged in `failed_checks["edge_without_evidence"]`
+- `test_date_tolerant_evidence_grouping()`: Tests date-tolerant evidence grouping for Issue #15:
+  - Evidence differing only in dates (dc:date, dcterms:created) is grouped together
+  - Annotation with date-differing evidence is classified as standard
+  - Evidence grouping produces correct number of groups with evidence from all edges
+- `test_date_update_on_split()`: Tests date update during evidence splitting for Issue #15:
+  - After splitting, all evidence nodes have the most recent dc:date (2023-02-13)
+  - Verifies the split output file has updated dates
+- `test_date_change_report()`: Tests date change record collection during splitting for Issue #15:
+  - Verifies split returns date change records with model ID, title, dates, and edge type URIs
+  - Verifies original and new dates differ, and new date is the most recent (2023-02-13)
+  - Verifies edge labels can be resolved via `term_label()`

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ GPAD_PROD := $(TARGET_DIR)/gpad_export_prod.gpad
 GPAD_DIFF := $(TARGET_DIR)/gpad_diff.txt
 REPORT_FILE := $(TARGET_DIR)/noctua_models_graph_counts_$(DATE).tsv
 CRITERIA_FAIL_REPORT := $(TARGET_DIR)/models_split_criteria_failures_$(DATE).tsv
+DATE_CHANGE_REPORT := $(TARGET_DIR)/date_changes_$(DATE).tsv
 
 # Default target
 .PHONY: all test clean pipeline
@@ -67,7 +68,9 @@ $(MODELS_SPLIT): $(GO_ONTOLOGY) $(RO_ONTOLOGY) $(GROUPS_YAML)
 		--split-evidence \
 		--output-dir $(MODELS_SPLIT) \
 		--report-file $(REPORT_FILE) \
-		--criteria-fail-report $(CRITERIA_FAIL_REPORT)
+		--criteria-fail-report $(CRITERIA_FAIL_REPORT) \
+		--date-change-report $(DATE_CHANGE_REPORT) \
+		| tee $(TARGET_DIR)/gocam_ttl.log
 	touch $@
 
 # Step 2: Copy original models that were split for comparison

--- a/resources/test/MGI_MGI_1101770.ttl
+++ b/resources/test/MGI_MGI_1101770.ttl
@@ -1,0 +1,1197 @@
+
+<http://model.geneontology.org/MGI_MGI_1101770> a <http://www.w3.org/2002/07/owl#Ontology> .
+
+<http://geneontology.org/lego/evidence> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://geneontology.org/lego/hint/layout/x> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://geneontology.org/lego/hint/layout/y> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://geneontology.org/lego/modelstate> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/BFO_0000050> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.obolibrary.org/obo/GO_0003674> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/RO_0002333> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.org/dc/terms/created> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.org/dc/terms/dateAccepted> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.org/pav/providedBy> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<https://w3id.org/biolink/vocab/in_taxon> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/BFO_0000066> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.obolibrary.org/obo/ECO_0000314> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/RO_0001025> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.obolibrary.org/obo/RO_0002418> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://geneontology.org/lego/evidence-with> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/ECO_0000353> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0005515> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/RO_0002233> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.obolibrary.org/obo/ECO_0000315> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/ECO_0000316> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/RO_0004047> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.obolibrary.org/obo/GO_0045892> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0003682> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/EMAPA_17214> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0006325> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0016604> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0000151> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/EMAPA_19472> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0009952> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0048593> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0031519> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0035102> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0097027> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/mgi/MGI:1101759> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/mgi/MGI:1101770> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://identifiers.org/mgi/MGI:96189> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/GO_0001739> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/PR_P22227> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/PR_Q00899> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/MGI_MGI_1101770> <http://geneontology.org/lego/modelstate> "production"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2002-11-20" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#versionIRI> <http://model.geneontology.org/MGI_MGI_1101770> ;
+	<https://w3id.org/biolink/vocab/in_taxon> <http://purl.obolibrary.org/obo/NCBITaxon_10090> ;
+	a <http://www.w3.org/2002/07/owl#Ontology> ;
+	<http://purl.org/dc/elements/1.1/title> "Ring1 (MGI:MGI:1101770)" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" , "https://orcid.org/0000-0003-2689-5511" , "https://orcid.org/0000-0001-5501-853X" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-03-03"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1101770/00f5ed3b-b1f8-4155-8dab-4d2ab904fa32> <http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://geneontology.org/lego/evidence-with> "MGI:MGI:1926913" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000315> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "anatomy lumbar vertebra 1 ; MA:0001428" , "anatomy thoracic vertebra 8 ; MA:0001445" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2020-10-15" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:16624538" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/02392ba3-f438-43cd-afdc-3f284a3fb42f> <http://geneontology.org/lego/hint/layout/x> "126.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "55"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1101770/bb6a1bbf-7fd1-48be-a395-37e98a69b39e> ;
+	<http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002233> <http://model.geneontology.org/MGI_MGI_1101770/f9800e7c-614b-42e0-bebe-2b5015432e33> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0097027> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-03-03"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1101770/02919d8e-f327-4b6c-98d2-2234bd23bb66> <http://geneontology.org/lego/hint/layout/x> "1623.75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "995"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/MGI_MGI_1101770/bdd4c679-58f7-4372-b2af-337cc498a225> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0009952> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-03-03"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1101770/0e5c857b-f57b-4c76-af7f-4626e22cb7bf> <http://geneontology.org/lego/hint/layout/x> "1194.38330078125"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "1016.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1101770/8037df15-efbc-4704-a737-49c61565982d> ;
+	<http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_1101770/02919d8e-f327-4b6c-98d2-2234bd23bb66> ;
+	a <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-03-03"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1101770/11355e29-fab7-402c-9242-692d0bb46ae5> <http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1101770> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2020-10-15" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/1455affb-ed4c-4783-94b2-cd75102aa8af> <http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "target Hoxb8 ; MGI:96189" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2006-08-08" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:16687444" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/16dbbcbd-5fb1-4591-a3bc-dc500cf67a95> <http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2021-03-24" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:16359901" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/191b8d36-5fa1-4c00-8991-aef0b28e8079> <http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://geneontology.org/lego/evidence-with> "MGI:MGI:99150" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000316> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "anatomy thoracic vertebra 10 ; MA:0001447" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2020-10-15" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:16624538" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/1aa13fea-42c6-4a79-93e4-6eba3c5e4fb5> <http://purl.org/dc/terms/created> "2013-04-02" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/PR_Q3TTC2> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2013-04-02" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/21c406bc-f673-421b-98d0-295fbd90e2dc> <http://geneontology.org/lego/hint/layout/x> "859"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "551"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0006325> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" , "https://orcid.org/0000-0001-5501-853X" ;
+	<http://purl.org/dc/elements/1.1/date> "2023-03-03"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1101770/239ad4e9-4573-4a1d-b9af-5c3688c059cd> <http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://geneontology.org/lego/evidence-with> "MGI:MGI:99150" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000316> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "anatomy TS25  anterior chamber ; EMAP:10572" , "anatomy TS25  lens ; EMAP:10595" , "has_participant(EMAPA:17838 TS25)" , "has_participant(EMAPA:18231 TS25)" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2006-08-08" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:16624538" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/243ddd31-dbc6-4f8d-a380-41a4517cc55a> <http://purl.org/dc/terms/created> "2013-04-02" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://geneontology.org/lego/evidence-with> "PR:P22227" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000353> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "evidence ECO:0000070 ; inferred from co-immunoprecipitation" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2013-04-02" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:21530438" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/26462a61-bf79-4703-badc-5771ec64ec3b> <http://purl.org/dc/terms/created> "2013-04-02" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1101770> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2013-04-02" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/299b2949-31ba-414c-89a3-cc12c8585648> <http://geneontology.org/lego/hint/layout/x> "392.5"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "226"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1101770/f9a8f7bb-94da-4647-acaf-0d6064583f00> ;
+	<http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002233> <http://model.geneontology.org/MGI_MGI_1101770/59a00a75-e818-4ed8-8f2f-580e9bf09d7e> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003682> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-03-03"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1101770/31af3970-0425-448a-b136-01e40352ca8b> <http://geneontology.org/lego/hint/layout/x> "2776.38330078125"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "353.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1101770/46830e88-b647-4519-861f-3f20e76a9fde> ;
+	<http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_1101770/e51dea59-8c97-4ec5-94f0-3c19548aa01c> ;
+	a <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-03-03"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1101770/32aae51b-142b-44b9-8624-3d928d40cfcb> <http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1101770> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-2689-5511" , "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2011-06-13" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/35b911fb-a8ec-4276-ab28-a0b1a03e9c1d> <http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://geneontology.org/lego/evidence-with> "MGI:MGI:1926913" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000315> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "anatomy TS26  axial skeleton ; EMAP:12383" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2020-10-15" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:11060235" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/37d50f38-e747-4d5a-bfa8-231072a89c23> <http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://geneontology.org/lego/evidence-with> "MGI:MGI:1926913" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000315> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "anatomy TS26  axial skeleton ; EMAP:12383" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2020-10-15" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:11060235" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/419425ff-4a5a-4915-9287-3d06783930a1> <http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://geneontology.org/lego/evidence-with> "MGI:MGI:1926913" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000315> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "anatomy lumbar vertebra 1 ; MA:0001428" , "anatomy thoracic vertebra 8 ; MA:0001445" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2020-10-15" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:16624538" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/4440dcf4-6e70-4509-856e-9280bbb1fbcc> <http://geneontology.org/lego/hint/layout/x> "2786.88330078125"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "203.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1101770/508f38a7-7d8c-4bfa-90ff-419cc7b83b64> ;
+	<http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_1101770/d5c93aa9-2109-4de7-9ab5-12f26e377d4c> ;
+	a <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-03-03"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1101770/451ce899-efb7-45d2-833d-683334d0c363> <http://geneontology.org/lego/hint/layout/x> "1552.13330078125"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "344.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1101770/11355e29-fab7-402c-9242-692d0bb46ae5> ;
+	<http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_1101770/fb8a7530-d3ec-4092-a935-f0cb748dc633> ;
+	a <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-03-03"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1101770/46830e88-b647-4519-861f-3f20e76a9fde> <http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1101770> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2020-10-15" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/48d6c532-967a-40a5-ad1f-cbba1d97cb0a> <http://geneontology.org/lego/hint/layout/x> "822.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "966"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0035102> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" , "https://orcid.org/0000-0001-5501-853X" ;
+	<http://purl.org/dc/elements/1.1/date> "2023-03-03"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1101770/4e16eb8a-b50d-4bde-969a-1c46457bc9f4> <http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://geneontology.org/lego/evidence-with> "MGI:MGI:1926913" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000315> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "anatomy lumbar vertebra 1 ; MA:0001428" , "anatomy thoracic vertebra 8 ; MA:0001445" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2020-10-15" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:16624538" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/508f38a7-7d8c-4bfa-90ff-419cc7b83b64> <http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1101770> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2020-10-15" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/5216f2b6-4a12-4823-9a3d-cc39322f1495> <http://geneontology.org/lego/hint/layout/x> "390.75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "47"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1101770/f10762d0-38c4-409d-b156-b89618d9c8f6> ;
+	<http://purl.org/dc/terms/created> "2013-04-02" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002233> <http://model.geneontology.org/MGI_MGI_1101770/9c39400b-0576-4b7a-a1aa-f45030a0592d> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005515> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" , "https://orcid.org/0000-0001-5501-853X" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-03-03"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1101770/542c8395-4ed1-44f3-a4c5-82a49278e2c9> <http://purl.org/dc/terms/created> "2013-04-02" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/PR_Q00899> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2013-04-02" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/54c44f9c-0d88-42e6-b85e-26225c241739> <http://geneontology.org/lego/hint/layout/x> "733.5"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "1108"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0001739> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" , "https://orcid.org/0000-0001-5501-853X" ;
+	<http://purl.org/dc/elements/1.1/date> "2023-03-03"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1101770/59a00a75-e818-4ed8-8f2f-580e9bf09d7e> <http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:96189> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2006-08-08" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/63e5937500000071> <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-02-13"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:16359901"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1101770/63e5937500000072> <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/evidence-with> "MGI:MGI:1101759"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000316> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-02-13"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:15525528"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1101770/646b4141-70d6-464d-9fd7-64099c5402ca> <http://purl.org/dc/terms/created> "2013-04-02" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://geneontology.org/lego/evidence-with> "PR:Q3TTC2" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000353> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "evidence ECO:0000070 ; inferred from co-immunoprecipitation" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2013-04-02" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:21530438" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/64843f01-4965-41c7-a73f-dd6704f659d9> <http://geneontology.org/lego/hint/layout/x> "1566.63330078125"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "606.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1101770/cd9bbf04-6503-435f-acd0-b4ecef054d95> ;
+	<http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_1101770/e7fdca8b-0ad2-4119-801d-a13e452294be> ;
+	a <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-03-03"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1101770/650175be-9f4d-4b05-8919-b3587cbc6e35> <http://geneontology.org/lego/hint/layout/x> "35.88330078125"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "882.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/MGI_MGI_1101770/ec4774f6-2e52-4c22-87b2-3cbbe40071a6> ;
+	<http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1101770> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-03-03"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1101770/67262ffe-64b6-45a9-bb53-bfe0175b4ee2> <http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-2689-5511" , "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2011-06-13" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:9312051" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/6b4551d2-8271-4474-90b9-cafe1e0de289> <http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://geneontology.org/lego/evidence-with> "MGI:MGI:1926913" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000315> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "anatomy TS26  axial skeleton ; EMAP:12383" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2020-10-15" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:11060235" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/6cfd0a4c-786f-4838-a7d3-d2e73d7e11bb> <http://purl.org/dc/terms/created> "2013-04-02" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://geneontology.org/lego/evidence-with> "PR:Q00899" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000353> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "evidence ECO:0000070 ; inferred from co-immunoprecipitation" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2013-04-02" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:21530438" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/756345b6-03a4-4b23-bfcd-9cbbc5b0bec6> <http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://geneontology.org/lego/evidence-with> "MGI:MGI:99150" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000316> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "anatomy thoracic vertebra 10 ; MA:0001447" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2020-10-15" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:16624538" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/776261f4-d425-449f-b1eb-cbbd95588b88> <http://purl.org/dc/terms/created> "2002-11-20" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2002-11-20" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:12183370" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/7d743da9-5854-468a-8dc2-2eb911df7dfa> <http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://geneontology.org/lego/evidence-with> "MGI:MGI:1926913" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000315> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "anatomy lumbar vertebra 1 ; MA:0001428" , "anatomy thoracic vertebra 8 ; MA:0001445" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2020-10-15" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:16624538" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/8037df15-efbc-4704-a737-49c61565982d> <http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1101770> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2020-10-15" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/807c7b6b-6769-48c6-8e77-a62f8b97ebe3> <http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://geneontology.org/lego/evidence-with> "MGI:MGI:99150" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000316> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "anatomy TS25  anterior chamber ; EMAP:10572" , "anatomy TS25  lens ; EMAP:10595" , "has_participant(EMAPA:17838 TS25)" , "has_participant(EMAPA:18231 TS25)" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2006-08-08" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:16624538" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/873660f1-6e60-4b1a-920e-44f8053f65fd> <http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2006-08-09" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:16359901" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/8cf7869d-22f9-4a55-9dea-cacb3dbcf35e> <http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/EMAPA_19551> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2020-10-15" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/8cfdde9d-f5e0-4de5-afd4-4de4b5aac83e> <http://geneontology.org/lego/hint/layout/x> "96.13333129882812"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "1112.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0001025> <http://model.geneontology.org/MGI_MGI_1101770/54c44f9c-0d88-42e6-b85e-26225c241739> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1101770> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-03-03"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1101770/9aaa0c92-22e5-4d5e-8f4d-b9c507cafe7d> <http://geneontology.org/lego/hint/layout/x> "854"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "657"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0045892> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-2689-5511" , "https://orcid.org/0000-0001-7476-6306" , "https://orcid.org/0000-0001-5501-853X" ;
+	<http://purl.org/dc/elements/1.1/date> "2023-03-03"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1101770/9bbb54e6-b060-4671-8ca8-fb969203205a> <http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2006-08-09" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:9312051" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/9c39400b-0576-4b7a-a1aa-f45030a0592d> <http://purl.org/dc/terms/created> "2013-04-02" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/PR_P22227> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2013-04-02" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/9fe48bbe-e0bc-413c-abe6-7c87b9ae23c5> <http://geneontology.org/lego/hint/layout/x> "25.883331298828125"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "966.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/MGI_MGI_1101770/48d6c532-967a-40a5-ad1f-cbba1d97cb0a> ;
+	<http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1101770> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-03-03"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1101770/a6bdc157-d5f8-4967-9ed0-11bc25c41829> <http://purl.org/dc/terms/created> "2013-04-02" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://geneontology.org/lego/evidence-with> "PR:Q3TTC2" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000353> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "evidence ECO:0000070 ; inferred from co-immunoprecipitation" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2013-04-02" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:21530438" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/a9c5f5d3-a960-420d-b052-1d264074a901> <http://geneontology.org/lego/hint/layout/x> "106.63333129882812"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "540.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1101770/b73214c9-6236-451d-85d8-f86c55ded329> ;
+	<http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0004047> <http://model.geneontology.org/MGI_MGI_1101770/21c406bc-f673-421b-98d0-295fbd90e2dc> ;
+	a <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-03-03"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1101770/aaf8af23-846f-427b-a914-4e61816304eb> <http://purl.org/dc/terms/created> "2013-04-02" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1101770> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2013-04-02" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/ad8378ea-973e-4a28-9998-268ba29fef0a> <http://purl.org/dc/terms/created> "2013-04-02" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://geneontology.org/lego/evidence-with> "PR:Q00899" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000353> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "evidence ECO:0000070 ; inferred from co-immunoprecipitation" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2013-04-02" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:21530438" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/b530cecc-b57d-4992-8a27-7d7d30b0bcd1> <http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2006-08-09" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:16359901" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/b73214c9-6236-451d-85d8-f86c55ded329> <http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1101770> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2006-08-09" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/ba80d389-c2fd-412d-8f54-98d8cd7402a5> <http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://geneontology.org/lego/evidence-with> "MGI:MGI:1101759" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000316> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2006-08-09" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:15525528" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/bb6a1bbf-7fd1-48be-a395-37e98a69b39e> <http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1101770> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2021-03-24" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/bc8435f9-63cb-4655-8116-f57a536b37e8> <http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://geneontology.org/lego/evidence-with> "MGI:MGI:1926913" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000315> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "anatomy lumbar vertebra 1 ; MA:0001428" , "anatomy thoracic vertebra 8 ; MA:0001445" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2020-10-15" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:16624538" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/bd73594b-8e31-4657-94f3-cc27f9e8cc6b> <http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/EMAPA_17214> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2020-10-15" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/bdd4c679-58f7-4372-b2af-337cc498a225> <http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/EMAPA_19472> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2020-10-15" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/c1d5ddfe-ab8a-4aef-9883-f51e3f284f23> <http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://geneontology.org/lego/evidence-with> "MGI:MGI:99150" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000316> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "anatomy thoracic vertebra 10 ; MA:0001447" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2020-10-15" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:16624538" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/ccfacb20-30fb-400c-9897-98392f9ab750> <http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/EMAPA_19549> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2020-10-15" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/cd9bbf04-6503-435f-acd0-b4ecef054d95> <http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1101770> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2006-08-08" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/cf669683-9733-4128-9f62-239ff2a48b23> <http://geneontology.org/lego/hint/layout/x> "856.75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "47"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1101770/aaf8af23-846f-427b-a914-4e61816304eb> ;
+	<http://purl.org/dc/terms/created> "2013-04-02" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002233> <http://model.geneontology.org/MGI_MGI_1101770/542c8395-4ed1-44f3-a4c5-82a49278e2c9> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005515> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" , "https://orcid.org/0000-0001-5501-853X" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-03-03"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1101770/d417a8f8-4504-45cc-af50-ef12c9e0b2b4> <http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "target Hoxb8 ; MGI:96189" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2006-08-08" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:16687444" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/d5c93aa9-2109-4de7-9ab5-12f26e377d4c> <http://geneontology.org/lego/hint/layout/x> "3274.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "198"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/MGI_MGI_1101770/bd73594b-8e31-4657-94f3-cc27f9e8cc6b> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0009952> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-03-03"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1101770/da6d685b-4920-4a24-81da-d7c8a1707395> <http://geneontology.org/lego/hint/layout/x> "3499.13330078125"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "955.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2002-11-20" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0001025> <http://model.geneontology.org/MGI_MGI_1101770/e4883e91-30fd-4438-8bd1-25be707ba87d> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1101770> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-03-03"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1101770/e4883e91-30fd-4438-8bd1-25be707ba87d> <http://geneontology.org/lego/hint/layout/x> "3786.5"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "847"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2002-11-20" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0016604> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" , "https://orcid.org/0000-0001-5501-853X" ;
+	<http://purl.org/dc/elements/1.1/date> "2023-03-03"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1101770/e51dea59-8c97-4ec5-94f0-3c19548aa01c> <http://geneontology.org/lego/hint/layout/x> "3304.75"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "319"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/MGI_MGI_1101770/8cf7869d-22f9-4a55-9dea-cacb3dbcf35e> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0009952> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-03-03"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1101770/e61fe9cf-639a-4c5c-bddf-6b4e6aece625> <http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-2689-5511" , "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2011-06-13" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:9312051" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/e6bfbd0b-e10d-41cf-999e-c04b7e51d887> <http://geneontology.org/lego/hint/layout/x> "621"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "48"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1101770/26462a61-bf79-4703-badc-5771ec64ec3b> ;
+	<http://purl.org/dc/terms/created> "2013-04-02" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002233> <http://model.geneontology.org/MGI_MGI_1101770/1aa13fea-42c6-4a79-93e4-6eba3c5e4fb5> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005515> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" , "https://orcid.org/0000-0001-5501-853X" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-03-03"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1101770/e7fdca8b-0ad2-4119-801d-a13e452294be> <http://geneontology.org/lego/hint/layout/x> "2776"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "511"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0048593> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" , "https://orcid.org/0000-0001-5501-853X" ;
+	<http://purl.org/dc/elements/1.1/date> "2023-03-03"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1101770/e9f9779e-a2f4-4b3f-bd9f-1819d7da1cd0> <http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2021-03-24" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:16359901" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/eb01051b-60f1-4b3f-8a58-34fc52f9bee8> <http://geneontology.org/lego/hint/layout/x> "115.38333129882812"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "697.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_1101770/32aae51b-142b-44b9-8624-3d928d40cfcb> ;
+	<http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_1101770/9aaa0c92-22e5-4d5e-8f4d-b9c507cafe7d> ;
+	a <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-2689-5511" , "https://orcid.org/0000-0001-5501-853X" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-03-03"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1101770/ec4774f6-2e52-4c22-87b2-3cbbe40071a6> <http://geneontology.org/lego/hint/layout/x> "828.25"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "880"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0031519> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" , "https://orcid.org/0000-0001-5501-853X" ;
+	<http://purl.org/dc/elements/1.1/date> "2023-03-03"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1101770/ee9087fb-1466-4090-81e2-6cb26d82ed12> <http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://geneontology.org/lego/evidence-with> "MGI:MGI:1926913" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000315> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "anatomy lumbar vertebra 1 ; MA:0001428" , "anatomy thoracic vertebra 8 ; MA:0001445" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2020-10-15" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:16624538" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/f10762d0-38c4-409d-b156-b89618d9c8f6> <http://purl.org/dc/terms/created> "2013-04-02" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1101770> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2013-04-02" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/f440c276-eeb9-439d-96b5-f7f8baa29873> <http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2006-08-08" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:16624538" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/f96b0f6b-517b-490b-b526-80fc650d4286> <http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000314> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2006-08-09" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:15525528" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/f9800e7c-614b-42e0-bebe-2b5015432e33> <http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1101759> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2021-03-24" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/f9a8f7bb-94da-4647-acaf-0d6064583f00> <http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/mgi/MGI:1101770> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/date> "2006-08-08" .
+
+<http://model.geneontology.org/MGI_MGI_1101770/fb8a7530-d3ec-4092-a935-f0cb748dc633> <http://geneontology.org/lego/hint/layout/x> "2092.5"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://geneontology.org/lego/hint/layout/y> "313"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/MGI_MGI_1101770/ccfacb20-30fb-400c-9897-98392f9ab750> ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0009952> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-03-03"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://model.geneontology.org/MGI_MGI_1101770/fdf82b89-b5b9-425b-8e45-a6c27e58bb49> <http://purl.org/dc/terms/created> "2013-04-02" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+	<http://geneontology.org/lego/evidence-with> "PR:P22227" ;
+	a <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000353> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "evidence ECO:0000070 ; inferred from co-immunoprecipitation" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2013-04-02" ;
+	<http://purl.org/dc/elements/1.1/source> "PMID:21530438" .
+
+<http://purl.obolibrary.org/obo/EMAPA_19549> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/EMAPA_19551> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/PR_Q3TTC2> a <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.org/dc/elements/1.1/title> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.org/dc/elements/1.1/contributor> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.org/dc/elements/1.1/date> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.org/dc/elements/1.1/source> a <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+_:t354260 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1101770/b530cecc-b57d-4992-8a27-7d7d30b0bcd1> , <http://model.geneontology.org/MGI_MGI_1101770/ba80d389-c2fd-412d-8f54-98d8cd7402a5> ;
+	<http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1101770/a9c5f5d3-a960-420d-b052-1d264074a901> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1101770/b73214c9-6236-451d-85d8-f86c55ded329> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1101770  RO:0002264 GO:0016574 MGI:MGI:3513221|PMID:15525528 ECO:0000316 MGI:MGI:1101759  2006-08-09 MGI  creation-date=2006-08-09|modification-date=2006-08-09|contributor-id=https://orcid.org/0000-0001-7476-6306" , "MGI:MGI:1101770  RO:0002264 GO:0016574 MGI:MGI:3612587|PMID:16359901 ECO:0000314   2006-08-09 MGI  creation-date=2006-08-09|modification-date=2006-08-09|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2006-08-09" .
+
+_:t354261 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1101770/67262ffe-64b6-45a9-bb53-bfe0175b4ee2> ;
+	<http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1101770/eb01051b-60f1-4b3f-8a58-34fc52f9bee8> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1101770/32aae51b-142b-44b9-8624-3d928d40cfcb> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1101770  RO:0002264 GO:0045892 MGI:MGI:1098085|PMID:9312051 ECO:0000314   2011-06-13 MGI  creation-date=2006-08-09|modification-date=2011-06-13|contributor-id=https://orcid.org/0000-0001-7476-6306|contributor-id=https://orcid.org/0000-0003-2689-5511" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-2689-5511" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2011-06-13" .
+
+_:t354262 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1101770/e61fe9cf-639a-4c5c-bddf-6b4e6aece625> ;
+	<http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002418> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1101770/eb01051b-60f1-4b3f-8a58-34fc52f9bee8> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1101770/9aaa0c92-22e5-4d5e-8f4d-b9c507cafe7d> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1101770  RO:0002264 GO:0045892 MGI:MGI:1098085|PMID:9312051 ECO:0000314   2011-06-13 MGI  creation-date=2006-08-09|modification-date=2011-06-13|contributor-id=https://orcid.org/0000-0001-7476-6306|contributor-id=https://orcid.org/0000-0003-2689-5511" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-2689-5511" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2011-06-13" .
+
+_:t354263 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1101770/4e16eb8a-b50d-4bde-969a-1c46457bc9f4> ;
+	<http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000066> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1101770/fb8a7530-d3ec-4092-a935-f0cb748dc633> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1101770/ccfacb20-30fb-400c-9897-98392f9ab750> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1101770  RO:0002264 GO:0009952 MGI:MGI:3628673|PMID:16624538 ECO:0000315 MGI:MGI:1926913  2020-10-15 MGI BFO:0000066(EMAPA:19549)|BFO:0000066(EMAPA:19472) creation-date=2006-08-08|modification-date=2020-10-15|comment=anatomy lumbar vertebra 1 ; MA:0001428|comment=anatomy thoracic vertebra 8 ; MA:0001445|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2020-10-15" .
+
+_:t354264 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1101770/ee9087fb-1466-4090-81e2-6cb26d82ed12> ;
+	<http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1101770/0e5c857b-f57b-4c76-af7f-4626e22cb7bf> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1101770/8037df15-efbc-4704-a737-49c61565982d> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1101770  RO:0002264 GO:0009952 MGI:MGI:3628673|PMID:16624538 ECO:0000315 MGI:MGI:1926913  2020-10-15 MGI BFO:0000066(EMAPA:19549)|BFO:0000066(EMAPA:19472) creation-date=2006-08-08|modification-date=2020-10-15|comment=anatomy lumbar vertebra 1 ; MA:0001428|comment=anatomy thoracic vertebra 8 ; MA:0001445|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2020-10-15" .
+
+_:t354265 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1101770/7d743da9-5854-468a-8dc2-2eb911df7dfa> ;
+	<http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002418> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1101770/0e5c857b-f57b-4c76-af7f-4626e22cb7bf> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1101770/02919d8e-f327-4b6c-98d2-2234bd23bb66> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1101770  RO:0002264 GO:0009952 MGI:MGI:3628673|PMID:16624538 ECO:0000315 MGI:MGI:1926913  2020-10-15 MGI BFO:0000066(EMAPA:19549)|BFO:0000066(EMAPA:19472) creation-date=2006-08-08|modification-date=2020-10-15|comment=anatomy lumbar vertebra 1 ; MA:0001428|comment=anatomy thoracic vertebra 8 ; MA:0001445|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2020-10-15" .
+
+_:t354266 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1101770/e9f9779e-a2f4-4b3f-bd9f-1819d7da1cd0> ;
+	<http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002233> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1101770/02392ba3-f438-43cd-afdc-3f284a3fb42f> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1101770/f9800e7c-614b-42e0-bebe-2b5015432e33> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1101770  RO:0002327 GO:0097027 MGI:MGI:3612587|PMID:16359901 ECO:0000314   2021-03-24 MGI RO:0002233(MGI:MGI:1101759) creation-date=2006-08-09|modification-date=2021-03-24|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-03-24" .
+
+_:t354267 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1101770/16dbbcbd-5fb1-4591-a3bc-dc500cf67a95> ;
+	<http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1101770/02392ba3-f438-43cd-afdc-3f284a3fb42f> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1101770/bb6a1bbf-7fd1-48be-a395-37e98a69b39e> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1101770  RO:0002327 GO:0097027 MGI:MGI:3612587|PMID:16359901 ECO:0000314   2021-03-24 MGI RO:0002233(MGI:MGI:1101759) creation-date=2006-08-09|modification-date=2021-03-24|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2021-03-24" .
+
+_:t354268 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1101770/bc8435f9-63cb-4655-8116-f57a536b37e8> ;
+	<http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000066> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1101770/02919d8e-f327-4b6c-98d2-2234bd23bb66> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1101770/bdd4c679-58f7-4372-b2af-337cc498a225> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1101770  RO:0002264 GO:0009952 MGI:MGI:3628673|PMID:16624538 ECO:0000315 MGI:MGI:1926913  2020-10-15 MGI BFO:0000066(EMAPA:19549)|BFO:0000066(EMAPA:19472) creation-date=2006-08-08|modification-date=2020-10-15|comment=anatomy lumbar vertebra 1 ; MA:0001428|comment=anatomy thoracic vertebra 8 ; MA:0001445|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2020-10-15" .
+
+_:t354269 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1101770/d417a8f8-4504-45cc-af50-ef12c9e0b2b4> ;
+	<http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002233> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1101770/299b2949-31ba-414c-89a3-cc12c8585648> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1101770/59a00a75-e818-4ed8-8f2f-580e9bf09d7e> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1101770  RO:0002327 GO:0003682 MGI:MGI:3629244|PMID:16687444 ECO:0000314   2006-08-08 MGI RO:0002233(MGI:MGI:96189) creation-date=2006-08-08|modification-date=2006-08-08|comment=target Hoxb8 ; MGI:96189|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2006-08-08" .
+
+_:t354270 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1101770/1455affb-ed4c-4783-94b2-cd75102aa8af> ;
+	<http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1101770/299b2949-31ba-414c-89a3-cc12c8585648> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1101770/f9a8f7bb-94da-4647-acaf-0d6064583f00> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1101770  RO:0002327 GO:0003682 MGI:MGI:3629244|PMID:16687444 ECO:0000314   2006-08-08 MGI RO:0002233(MGI:MGI:96189) creation-date=2006-08-08|modification-date=2006-08-08|comment=target Hoxb8 ; MGI:96189|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2006-08-08" .
+
+_:t354271 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1101770/63e5937500000071> , <http://model.geneontology.org/MGI_MGI_1101770/63e5937500000072> ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0004047> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1101770/a9c5f5d3-a960-420d-b052-1d264074a901> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1101770/21c406bc-f673-421b-98d0-295fbd90e2dc> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-02-13"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+_:t354272 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1101770/c1d5ddfe-ab8a-4aef-9883-f51e3f284f23> ;
+	<http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1101770/31af3970-0425-448a-b136-01e40352ca8b> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1101770/46830e88-b647-4519-861f-3f20e76a9fde> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1101770  RO:0002264 GO:0009952 MGI:MGI:3628673|PMID:16624538 ECO:0000316 MGI:MGI:99150  2020-10-15 MGI BFO:0000066(EMAPA:19551) creation-date=2006-08-08|modification-date=2020-10-15|comment=anatomy thoracic vertebra 10 ; MA:0001447|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2020-10-15" .
+
+_:t354273 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1101770/191b8d36-5fa1-4c00-8991-aef0b28e8079> ;
+	<http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002418> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1101770/31af3970-0425-448a-b136-01e40352ca8b> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1101770/e51dea59-8c97-4ec5-94f0-3c19548aa01c> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1101770  RO:0002264 GO:0009952 MGI:MGI:3628673|PMID:16624538 ECO:0000316 MGI:MGI:99150  2020-10-15 MGI BFO:0000066(EMAPA:19551) creation-date=2006-08-08|modification-date=2020-10-15|comment=anatomy thoracic vertebra 10 ; MA:0001447|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2020-10-15" .
+
+_:t354274 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1101770/35b911fb-a8ec-4276-ab28-a0b1a03e9c1d> ;
+	<http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1101770/4440dcf4-6e70-4509-856e-9280bbb1fbcc> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1101770/508f38a7-7d8c-4bfa-90ff-419cc7b83b64> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1101770  RO:0002264 GO:0009952 MGI:MGI:1926247|PMID:11060235 ECO:0000315 MGI:MGI:1926913  2020-10-15 MGI BFO:0000066(EMAPA:17214) creation-date=2006-08-09|modification-date=2020-10-15|comment=anatomy TS26  axial skeleton ; EMAP:12383|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2020-10-15" .
+
+_:t354275 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1101770/37d50f38-e747-4d5a-bfa8-231072a89c23> ;
+	<http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002418> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1101770/4440dcf4-6e70-4509-856e-9280bbb1fbcc> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1101770/d5c93aa9-2109-4de7-9ab5-12f26e377d4c> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1101770  RO:0002264 GO:0009952 MGI:MGI:1926247|PMID:11060235 ECO:0000315 MGI:MGI:1926913  2020-10-15 MGI BFO:0000066(EMAPA:17214) creation-date=2006-08-09|modification-date=2020-10-15|comment=anatomy TS26  axial skeleton ; EMAP:12383|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2020-10-15" .
+
+_:t354276 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1101770/419425ff-4a5a-4915-9287-3d06783930a1> ;
+	<http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1101770/451ce899-efb7-45d2-833d-683334d0c363> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1101770/11355e29-fab7-402c-9242-692d0bb46ae5> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1101770  RO:0002264 GO:0009952 MGI:MGI:3628673|PMID:16624538 ECO:0000315 MGI:MGI:1926913  2020-10-15 MGI BFO:0000066(EMAPA:19549)|BFO:0000066(EMAPA:19472) creation-date=2006-08-08|modification-date=2020-10-15|comment=anatomy lumbar vertebra 1 ; MA:0001428|comment=anatomy thoracic vertebra 8 ; MA:0001445|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2020-10-15" .
+
+_:t354277 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1101770/00f5ed3b-b1f8-4155-8dab-4d2ab904fa32> ;
+	<http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002418> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1101770/451ce899-efb7-45d2-833d-683334d0c363> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1101770/fb8a7530-d3ec-4092-a935-f0cb748dc633> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1101770  RO:0002264 GO:0009952 MGI:MGI:3628673|PMID:16624538 ECO:0000315 MGI:MGI:1926913  2020-10-15 MGI BFO:0000066(EMAPA:19549)|BFO:0000066(EMAPA:19472) creation-date=2006-08-08|modification-date=2020-10-15|comment=anatomy lumbar vertebra 1 ; MA:0001428|comment=anatomy thoracic vertebra 8 ; MA:0001445|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2020-10-15" .
+
+_:t354278 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1101770/243ddd31-dbc6-4f8d-a380-41a4517cc55a> ;
+	<http://purl.org/dc/terms/created> "2013-04-02" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002233> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1101770/5216f2b6-4a12-4823-9a3d-cc39322f1495> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1101770/9c39400b-0576-4b7a-a1aa-f45030a0592d> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1101770  RO:0002327 GO:0005515 MGI:MGI:5469575|PMID:21530438 ECO:0000353 PR:Q00899|PR:Q3TTC2|PR:P22227  2013-04-02 MGI  creation-date=2013-04-02|modification-date=2013-04-02|comment=evidence ECO:0000070 ; inferred from co-immunoprecipitation|contributor-id=https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2013-04-02" .
+
+_:t354279 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1101770/fdf82b89-b5b9-425b-8e45-a6c27e58bb49> ;
+	<http://purl.org/dc/terms/created> "2013-04-02" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1101770/5216f2b6-4a12-4823-9a3d-cc39322f1495> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1101770/f10762d0-38c4-409d-b156-b89618d9c8f6> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1101770  RO:0002327 GO:0005515 MGI:MGI:5469575|PMID:21530438 ECO:0000353 PR:Q00899|PR:Q3TTC2|PR:P22227  2013-04-02 MGI  creation-date=2013-04-02|modification-date=2013-04-02|comment=evidence ECO:0000070 ; inferred from co-immunoprecipitation|contributor-id=https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2013-04-02" .
+
+_:t354280 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1101770/239ad4e9-4573-4a1d-b9af-5c3688c059cd> ;
+	<http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1101770/64843f01-4965-41c7-a73f-dd6704f659d9> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1101770/cd9bbf04-6503-435f-acd0-b4ecef054d95> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1101770  RO:0002264 GO:0048593 MGI:MGI:3628673|PMID:16624538 ECO:0000316 MGI:MGI:99150  2006-08-08 MGI  creation-date=2006-08-08|modification-date=2006-08-08|comment=anatomy TS25  anterior chamber ; EMAP:10572|comment=anatomy TS25  lens ; EMAP:10595|comment=has_participant(EMAPA:17838 TS25)|comment=has_participant(EMAPA:18231 TS25)|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2006-08-08" .
+
+_:t354281 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1101770/807c7b6b-6769-48c6-8e77-a62f8b97ebe3> ;
+	<http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002418> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1101770/64843f01-4965-41c7-a73f-dd6704f659d9> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1101770/e7fdca8b-0ad2-4119-801d-a13e452294be> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1101770  RO:0002264 GO:0048593 MGI:MGI:3628673|PMID:16624538 ECO:0000316 MGI:MGI:99150  2006-08-08 MGI  creation-date=2006-08-08|modification-date=2006-08-08|comment=anatomy TS25  anterior chamber ; EMAP:10572|comment=anatomy TS25  lens ; EMAP:10595|comment=has_participant(EMAPA:17838 TS25)|comment=has_participant(EMAPA:18231 TS25)|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2006-08-08" .
+
+_:t354282 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1101770/ad8378ea-973e-4a28-9998-268ba29fef0a> ;
+	<http://purl.org/dc/terms/created> "2013-04-02" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002233> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1101770/cf669683-9733-4128-9f62-239ff2a48b23> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1101770/542c8395-4ed1-44f3-a4c5-82a49278e2c9> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1101770  RO:0002327 GO:0005515 MGI:MGI:5469575|PMID:21530438 ECO:0000353 PR:Q00899|PR:Q3TTC2|PR:P22227  2013-04-02 MGI  creation-date=2013-04-02|modification-date=2013-04-02|comment=evidence ECO:0000070 ; inferred from co-immunoprecipitation|contributor-id=https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2013-04-02" .
+
+_:t354283 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1101770/9bbb54e6-b060-4671-8ca8-fb969203205a> , <http://model.geneontology.org/MGI_MGI_1101770/f440c276-eeb9-439d-96b5-f7f8baa29873> ;
+	<http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000050> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1101770/650175be-9f4d-4b05-8919-b3587cbc6e35> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1101770/ec4774f6-2e52-4c22-87b2-3cbbe40071a6> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1101770  BFO:0000050 GO:0031519 MGI:MGI:1098085|PMID:9312051 ECO:0000314   2006-08-09 MGI  creation-date=2006-08-09|modification-date=2006-08-09|contributor-id=https://orcid.org/0000-0001-7476-6306" , "MGI:MGI:1101770  BFO:0000050 GO:0031519 MGI:MGI:3612587|PMID:16359901 ECO:0000314   2006-08-09 MGI  creation-date=2006-08-09|modification-date=2006-08-09|contributor-id=https://orcid.org/0000-0001-7476-6306" , "MGI:MGI:1101770  BFO:0000050 GO:0031519 MGI:MGI:3628673|PMID:16624538 ECO:0000314   2006-08-08 MGI  creation-date=2006-08-08|modification-date=2006-08-08|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" , "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2023-03-03"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+_:t354284 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1101770/f96b0f6b-517b-490b-b526-80fc650d4286> ;
+	<http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0001025> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1101770/8cfdde9d-f5e0-4de5-afd4-4de4b5aac83e> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1101770/54c44f9c-0d88-42e6-b85e-26225c241739> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1101770  RO:0001025 GO:0001739 MGI:MGI:3513221|PMID:15525528 ECO:0000314   2006-08-09 MGI  creation-date=2006-08-09|modification-date=2006-08-09|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2006-08-09" .
+
+_:t354285 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1101770/873660f1-6e60-4b1a-920e-44f8053f65fd> ;
+	<http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000050> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1101770/9fe48bbe-e0bc-413c-abe6-7c87b9ae23c5> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1101770/48d6c532-967a-40a5-ad1f-cbba1d97cb0a> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1101770  BFO:0000050 GO:0000151 MGI:MGI:3612587|PMID:16359901 ECO:0000314   2006-08-09 MGI  creation-date=2006-08-09|modification-date=2006-08-09|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2006-08-09" .
+
+_:t354286 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1101770/6cfd0a4c-786f-4838-a7d3-d2e73d7e11bb> ;
+	<http://purl.org/dc/terms/created> "2013-04-02" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1101770/cf669683-9733-4128-9f62-239ff2a48b23> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1101770/aaf8af23-846f-427b-a914-4e61816304eb> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1101770  RO:0002327 GO:0005515 MGI:MGI:5469575|PMID:21530438 ECO:0000353 PR:Q00899|PR:Q3TTC2|PR:P22227  2013-04-02 MGI  creation-date=2013-04-02|modification-date=2013-04-02|comment=evidence ECO:0000070 ; inferred from co-immunoprecipitation|contributor-id=https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2013-04-02" .
+
+_:t354287 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1101770/6b4551d2-8271-4474-90b9-cafe1e0de289> ;
+	<http://purl.org/dc/terms/created> "2006-08-09" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000066> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1101770/d5c93aa9-2109-4de7-9ab5-12f26e377d4c> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1101770/bd73594b-8e31-4657-94f3-cc27f9e8cc6b> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1101770  RO:0002264 GO:0009952 MGI:MGI:1926247|PMID:11060235 ECO:0000315 MGI:MGI:1926913  2020-10-15 MGI BFO:0000066(EMAPA:17214) creation-date=2006-08-09|modification-date=2020-10-15|comment=anatomy TS26  axial skeleton ; EMAP:12383|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2020-10-15" .
+
+_:t354288 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1101770/776261f4-d425-449f-b1eb-cbbd95588b88> ;
+	<http://purl.org/dc/terms/created> "2002-11-20" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0001025> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1101770/da6d685b-4920-4a24-81da-d7c8a1707395> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1101770/e4883e91-30fd-4438-8bd1-25be707ba87d> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1101770  RO:0001025 GO:0016604 MGI:MGI:2389282|PMID:12183370 ECO:0000314   2002-11-20 MGI  creation-date=2002-11-20|modification-date=2002-11-20|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2002-11-20" .
+
+_:t354289 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1101770/756345b6-03a4-4b23-bfcd-9cbbc5b0bec6> ;
+	<http://purl.org/dc/terms/created> "2006-08-08" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/BFO_0000066> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1101770/e51dea59-8c97-4ec5-94f0-3c19548aa01c> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1101770/8cf7869d-22f9-4a55-9dea-cacb3dbcf35e> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1101770  RO:0002264 GO:0009952 MGI:MGI:3628673|PMID:16624538 ECO:0000316 MGI:MGI:99150  2020-10-15 MGI BFO:0000066(EMAPA:19551) creation-date=2006-08-08|modification-date=2020-10-15|comment=anatomy thoracic vertebra 10 ; MA:0001447|contributor-id=https://orcid.org/0000-0001-7476-6306" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://purl.org/dc/elements/1.1/date> "2020-10-15" .
+
+_:t354290 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1101770/646b4141-70d6-464d-9fd7-64099c5402ca> ;
+	<http://purl.org/dc/terms/created> "2013-04-02" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002233> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1101770/e6bfbd0b-e10d-41cf-999e-c04b7e51d887> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1101770/1aa13fea-42c6-4a79-93e4-6eba3c5e4fb5> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1101770  RO:0002327 GO:0005515 MGI:MGI:5469575|PMID:21530438 ECO:0000353 PR:Q00899|PR:Q3TTC2|PR:P22227  2013-04-02 MGI  creation-date=2013-04-02|modification-date=2013-04-02|comment=evidence ECO:0000070 ; inferred from co-immunoprecipitation|contributor-id=https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2013-04-02" .
+
+_:t354291 <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_1101770/a6bdc157-d5f8-4967-9ed0-11bc25c41829> ;
+	<http://purl.org/dc/terms/created> "2013-04-02" ;
+	<http://purl.org/dc/terms/dateAccepted> "2022-03-28" ;
+	<http://purl.org/pav/providedBy> "http://informatics.jax.org"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	<http://www.w3.org/2002/07/owl#annotatedProperty> <http://purl.obolibrary.org/obo/RO_0002333> ;
+	<http://www.w3.org/2002/07/owl#annotatedSource> <http://model.geneontology.org/MGI_MGI_1101770/e6bfbd0b-e10d-41cf-999e-c04b7e51d887> ;
+	<http://www.w3.org/2002/07/owl#annotatedTarget> <http://model.geneontology.org/MGI_MGI_1101770/26462a61-bf79-4703-badc-5771ec64ec3b> ;
+	a <http://www.w3.org/2002/07/owl#Axiom> ;
+	<http://www.w3.org/2000/01/rdf-schema#comment> "MGI:MGI:1101770  RO:0002327 GO:0005515 MGI:MGI:5469575|PMID:21530438 ECO:0000353 PR:Q00899|PR:Q3TTC2|PR:P22227  2013-04-02 MGI  creation-date=2013-04-02|modification-date=2013-04-02|comment=evidence ECO:0000070 ; inferred from co-immunoprecipitation|contributor-id=https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+	<http://purl.org/dc/elements/1.1/date> "2013-04-02" .

--- a/src/gocam_unwinder/gocam_ttl.py
+++ b/src/gocam_unwinder/gocam_ttl.py
@@ -23,6 +23,7 @@ parser.add_argument('--criteria-fail-report', help="Output file for standard ann
 parser.add_argument('--skip-prefix', action='append', dest='skip_prefixes', metavar='PREFIX',
                     help="Skip files starting with PREFIX (can be specified multiple times, e.g., --skip-prefix SYNGO --skip-prefix R-HSA)")
 parser.add_argument('--groups-yaml', help="Path to groups.yaml for resolving group URIs to labels")
+parser.add_argument('--date-change-report', help="Output TSV file for date change report (model ID, title, original/new dates, edge labels)")
 
 GOCAM_RELATIONS = [str(r) for r in relations.__relation_label_lookup.values()]
 
@@ -171,11 +172,20 @@ class GoCamGraph:
         """
         Extract metadata for an evidence individual as a hashable tuple.
         This creates a signature that can identify equivalent evidence across edges.
+        Excludes date predicates (dc:date, dcterms:created, dcterms:dateAccepted) so that
+        evidence differing only in dates can be grouped together.
         """
+        date_predicates = {
+            rdflib.namespace.DC.date,
+            rdflib.namespace.DCTERMS.created,
+            rdflib.namespace.DCTERMS.dateAccepted,
+        }
         metadata = []
 
-        # Collect predicates defined in PREDICATES_TO_COPY
+        # Collect predicates defined in PREDICATES_TO_COPY, excluding date predicates
         for pred in self.PREDICATES_TO_COPY:
+            if pred in date_predicates:
+                continue  # Skip date predicates - handled separately during splitting
             values = sorted([str(obj) for obj in self.g.objects(evidence_uri, pred)])
             if values:
                 metadata.append((str(pred), tuple(values)))
@@ -245,6 +255,32 @@ class GoCamGraph:
 
         return groups
 
+    def get_most_recent_date(self, evidence_uris):
+        """
+        Find the most recent dc:date across a list of evidence URIs.
+        Returns the most recent date string, or None if no dates found.
+        """
+        date_pred = rdflib.namespace.DC.date
+        dates = []
+        for ev_uri in evidence_uris:
+            for date_val in self.g.objects(ev_uri, date_pred):
+                dates.append(str(date_val))
+        if dates:
+            return max(dates)  # ISO date strings sort lexicographically
+        return None
+
+    def update_evidence_date(self, evidence_uris, new_date):
+        """
+        Update dc:date on all given evidence URIs to the new_date value.
+        Removes existing dc:date triples and adds the new one.
+        """
+        date_pred = rdflib.namespace.DC.date
+        for ev_uri in evidence_uris:
+            # Remove existing dc:date
+            self.g.remove((ev_uri, date_pred, None))
+            # Add new dc:date
+            self.g.add((ev_uri, date_pred, rdflib.Literal(new_date)))
+
     def split_evidence_and_write_ttl(self, filename):
         """
         Split multi-evidence edges by grouping evidence with identical metadata across edges.
@@ -256,12 +292,57 @@ class GoCamGraph:
 
         This ensures that evidence representing the same "evidence event" across
         different edges stays together in the split annotations.
+
+        Returns a list of date change records (dicts with keys: model_id, title,
+        original_date, new_date, source_type, property_uri, target_type) for edges
+        where dc:date was updated.
         """
         evidence_pred = rdflib.URIRef("http://geneontology.org/lego/evidence")
+        date_change_records = []
 
         for std_annot in self.standard_annotations:
             # Get evidence groups for this annotation
             evidence_groups = self.group_evidence_by_metadata(std_annot)
+
+            # Update dc:date to most recent for each evidence group
+            date_pred = rdflib.namespace.DC.date
+            for group_index, group_edges in evidence_groups.items():
+                all_evidence_in_group = []
+                for edge_evidence_list in group_edges.values():
+                    all_evidence_in_group.extend(edge_evidence_list)
+                # Collect all distinct dates in this group
+                all_dates = set()
+                for ev_uri in all_evidence_in_group:
+                    for date_val in self.g.objects(ev_uri, date_pred):
+                        all_dates.add(str(date_val))
+                # Only update if dates actually differ
+                if len(all_dates) > 1:
+                    most_recent_date = max(all_dates)
+                    # Collect per-edge date changes before updating
+                    for edge_bnode_id, edge_evidence_list in group_edges.items():
+                        edge = std_annot.edges[edge_bnode_id]
+                        edge_dates = set()
+                        for ev_uri in edge_evidence_list:
+                            for date_val in self.g.objects(ev_uri, date_pred):
+                                edge_dates.add(str(date_val))
+                        for orig_date in edge_dates:
+                            if orig_date != most_recent_date:
+                                date_change_records.append({
+                                    "model_id": self.model_id,
+                                    "title": self.title,
+                                    "original_date": orig_date,
+                                    "new_date": most_recent_date,
+                                    "source_type": edge.source_type,
+                                    "property_uri": edge.property_uri,
+                                    "target_type": edge.target_type,
+                                })
+                    print(f"Date updated to {most_recent_date} for {self.model_id} ({self.title})")
+                    self.update_evidence_date(all_evidence_in_group, most_recent_date)
+                    # Also update dc:date on the BNode axioms for each edge
+                    for edge_bnode_id in group_edges.keys():
+                        bnode = rdflib.term.BNode(edge_bnode_id)
+                        self.g.remove((bnode, date_pred, None))
+                        self.g.add((bnode, date_pred, rdflib.Literal(most_recent_date)))
 
             # Track which individuals have been created for each group
             # Map: (original_uri, group_suffix) -> new_uri
@@ -321,6 +402,7 @@ class GoCamGraph:
                             self.g.add((new_bnode, evidence_pred, evidence_uri))
 
         self.write_ttl(filename)
+        return date_change_records
 
     def clone_bnode(self, old_bnode: rdflib.term.BNode, new_bnode: rdflib.term.BNode):
         # Clone the bnode and its properties to a new bnode
@@ -784,6 +866,8 @@ if __name__ == "__main__":
     if args.split_evidence and args.output_dir:
         os.makedirs(args.output_dir, exist_ok=True)
 
+    all_date_change_records = []
+
     for f in model_files:
         gocam_graph = go_cam_graph_builder.parse_ttl(f)
 
@@ -862,8 +946,22 @@ if __name__ == "__main__":
                 base_name = os.path.splitext(f)[0]
                 output_filename = base_name + "_split.ttl"
 
-            gocam_graph.split_evidence_and_write_ttl(output_filename)
+            date_records = gocam_graph.split_evidence_and_write_ttl(output_filename)
+            all_date_change_records.extend(date_records)
             print(f"Split evidence for {filename} -> {output_filename}")
+
+    # Write date change report if requested
+    if args.date_change_report and all_date_change_records:
+        with open(args.date_change_report, 'w') as dcr_file:
+            dcr_headers = ["Model ID", "Title", "Original Date", "New Date", "Source", "Predicate", "Target"]
+            print("\t".join(dcr_headers), file=dcr_file)
+            for rec in all_date_change_records:
+                source_label = go_cam_graph_builder.term_label(rec["source_type"]) if rec["source_type"] else ""
+                pred_label = go_cam_graph_builder.term_label(rec["property_uri"]) if rec["property_uri"] else ""
+                target_label = go_cam_graph_builder.term_label(rec["target_type"]) if rec["target_type"] else ""
+                cols = [rec["model_id"], rec["title"], rec["original_date"], rec["new_date"],
+                        source_label, pred_label, target_label]
+                print("\t".join(cols), file=dcr_file)
 
     # Close report file if it was opened
     if report_file:

--- a/tests/test_gocam_ttl.py
+++ b/tests/test_gocam_ttl.py
@@ -484,3 +484,112 @@ def test_edge_without_evidence_all_edges_no_evidence():
     assert len(no_ev_edge_bnodes) == len(actual_no_ev_edges), \
         f"All {len(actual_no_ev_edges)} no-evidence edges should be flagged, got {len(no_ev_edge_bnodes)}"
     assert len(actual_no_ev_edges) == 3, "Should have 3 edges without evidence"
+
+
+def test_date_tolerant_evidence_grouping():
+    """
+    Test that evidence differing only in dc:date is grouped together.
+
+    Issue #15: Model MGI_MGI_1101770 has an annotation where the enabled_by
+    edge has evidence dated 2006-08-09 and the causally_upstream_of edge has
+    evidence dated 2023-02-13. The evidence is otherwise identical (same ECO,
+    same PMID, same contributor). These should be grouped together, and the
+    date should be updated to the most recent (2023-02-13).
+    """
+    builder = GoCamGraphBuilder(ontology_file)
+    gocam_graph = builder.parse_ttl("resources/test/MGI_MGI_1101770.ttl")
+
+    # Individual a9c5f5d3 is the Ring1 MF activity with date-differing evidence
+    test_individual = rdflib.term.URIRef(
+        'http://model.geneontology.org/MGI_MGI_1101770/a9c5f5d3-a960-420d-b052-1d264074a901')
+
+    # This annotation should be classified as standard (not filtered out)
+    std_annot = gocam_graph.get_standard_annotation_by_individual(test_individual)
+    assert std_annot is not None, \
+        "Date-differing evidence annotation should be standard (not filtered out)"
+    assert len(std_annot.edges) == 2, "Annotation should have 2 edges"
+
+    # Evidence grouping should produce 2 groups (one per PMID/ECO pair)
+    evidence_groups = gocam_graph.group_evidence_by_metadata(std_annot)
+    assert len(evidence_groups) == 2, \
+        f"Should have 2 evidence groups, got {len(evidence_groups)}"
+
+    # Each group should have evidence from both edges
+    for group_index, group_edges in evidence_groups.items():
+        assert len(group_edges) == 2, \
+            f"Group {group_index} should have evidence from both edges"
+
+
+def test_date_update_on_split():
+    """
+    Test that after splitting, evidence nodes are updated to the most recent dc:date.
+
+    Issue #15: When evidence is grouped across edges that have different dates,
+    the split output should use the most recent date for all evidence in the group.
+    """
+    builder = GoCamGraphBuilder(ontology_file)
+    gocam_graph = builder.parse_ttl("resources/test/MGI_MGI_1101770.ttl")
+
+    # Split and write
+    gocam_graph.split_evidence_and_write_ttl("target/MGI_MGI_1101770_split.ttl")
+
+    # Reload the split model
+    split_graph = rdflib.Graph()
+    split_graph.parse("target/MGI_MGI_1101770_split.ttl", format="turtle")
+
+    # Find all evidence URIs attached to the annotation edges for individual a9c5f5d3
+    # The evidence should all have the most recent date (2023-02-13)
+    date_pred = rdflib.namespace.DC.date
+    evidence_pred = rdflib.URIRef("http://geneontology.org/lego/evidence")
+
+    # Collect all evidence URIs from edges that reference individual a9c5f5d3
+    test_individual = rdflib.URIRef(
+        'http://model.geneontology.org/MGI_MGI_1101770/a9c5f5d3-a960-420d-b052-1d264074a901')
+    evidence_uris = set()
+    for bnode, _, _ in split_graph.triples((None, rdflib.namespace.OWL.annotatedSource, test_individual)):
+        for _, _, ev_uri in split_graph.triples((bnode, evidence_pred, None)):
+            evidence_uris.add(ev_uri)
+    for bnode, _, _ in split_graph.triples((None, rdflib.namespace.OWL.annotatedTarget, test_individual)):
+        for _, _, ev_uri in split_graph.triples((bnode, evidence_pred, None)):
+            evidence_uris.add(ev_uri)
+
+    assert len(evidence_uris) > 0, "Should find evidence URIs for the test individual"
+
+    # All evidence should have dc:date = "2023-02-13" (the most recent)
+    for ev_uri in evidence_uris:
+        dates = list(split_graph.objects(ev_uri, date_pred))
+        assert len(dates) == 1, f"Evidence {ev_uri} should have exactly 1 dc:date, got {len(dates)}"
+        assert str(dates[0]) == "2023-02-13", \
+            f"Evidence {ev_uri} should have date 2023-02-13, got {str(dates[0])}"
+
+
+def test_date_change_report():
+    """
+    Test that splitting produces date change records with edge info.
+
+    Issue #15: Records should include model ID, title, old date, new date,
+    and source/predicate/target type URIs for each updated edge.
+    """
+    builder = GoCamGraphBuilder(ontology_file)
+    gocam_graph = builder.parse_ttl("resources/test/MGI_MGI_1101770.ttl")
+
+    # Split and collect date change records
+    date_change_records = gocam_graph.split_evidence_and_write_ttl("target/MGI_MGI_1101770_split.ttl")
+
+    assert len(date_change_records) >= 1, "Should have at least 1 date change record"
+
+    for rec in date_change_records:
+        assert "MGI_MGI_1101770" in rec["model_id"]
+        assert rec["original_date"] != rec["new_date"], "Original and new dates should differ"
+        assert rec["new_date"] == "2023-02-13", "New date should be the most recent"
+        assert rec["source_type"] is not None, "Source type should not be None"
+        assert rec["property_uri"] is not None, "Property URI should not be None"
+        assert rec["target_type"] is not None, "Target type should not be None"
+
+        # Verify labels can be resolved
+        source_label = builder.term_label(rec["source_type"])
+        pred_label = builder.term_label(rec["property_uri"])
+        target_label = builder.term_label(rec["target_type"])
+        assert source_label, "Source label should not be empty"
+        assert pred_label, "Predicate label should not be empty"
+        assert target_label, "Target label should not be empty"


### PR DESCRIPTION
For #15.

This considers same-annotation evidence differing only by date to still be the same evidence, allowing for unwinding to occur if necessary. The older date(s) will then be changed to the most recent date for consistency.

Code change also writes a report of models with changed dates to `date_changes_YYYYMMDD.tsv`.