### PR TITLE
[bot] Add standard-annotation ratchet pipeline + explorable dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 *.pyc
+__pycache__/
 target/*
+target_*/
+env/
+*.egg-info/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,22 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 GO-CAM Evidence Unwinder is a Python tool that processes Gene Ontology Causal Activity Models (GO-CAM) in RDF/TTL format. The tool identifies "standard annotations" (annotation units with edges connected to multiple evidence nodes) and can optionally "unwind" them by duplicating the annotation for each evidence, ensuring all edges have only one evidence node.
 
+### Standard-Annotation Ratchet (local-only subsystem)
+
+Branch `local/std-annot-ratchet` adds a **local-only** (not yet upstream) sibling
+subsystem `src/gocam_unwinder/ratchet/` that reuses this tool's checks to filter
+the whole noctua-models corpus down to standard annotations via a two-level,
+monotonic, sharded pipeline, with rules-as-data in `rules/` and a self-contained
+HTML dashboard (`gocam_unwinder.ratchet.dashboard`). Design, the corpus-run
+recipe, and findings live in
+`docs/plans/2026-06-25-standard-annotation-ratchet.md`.
+
+**Contract for `gocam_ttl.py` editors:** `filter_out_non_std_annotations()` is now
+a thin loop over per-check callables `GoCamGraphBuilder.check_<key>(gcg, sa)`
+(assembled by `run_all_checks`); Phase B of the ratchet depends on these. Keep the
+split behavior-preserving — if you add/change a check, update the `check_<key>`
+callable and `UNIT_CHECK_KEYS`, not a re-inlined loop.
+
 ## Development Commands
 
 ### Setup

--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,77 @@ $(NON_STD_REPORT): $(GO_ONTOLOGY) $(RO_ONTOLOGY) $(GROUPS_YAML)
 .PHONY: non_std
 non_std: $(NON_STD_REPORT)
 
+# ----------------------------------------------------------------------
+# Standard-annotation ratchet (local two-level filtering mini-pipeline).
+# Rules are data in rules/; see docs/plans/2026-06-25-standard-annotation-ratchet.md
+# ----------------------------------------------------------------------
+# The noctua-models corpus (S0). `make corpus` shallow-clones it as a sibling if
+# absent; override NOCTUA_MODELS_DIR to point at an existing checkout.
+NOCTUA_MODELS_DIR ?= ../noctua-models
+NOCTUA_MODELS_REPO ?= https://github.com/geneontology/noctua-models.git
+RATCHET_MODELS_DIR ?= $(NOCTUA_MODELS_DIR)/models
+# Where a run writes. Override to point the dashboard at a prior run's dir.
+RATCHET_OUT ?= $(TARGET_DIR)/ratchet
+# R1 source for "not a true GO-CAM": the published pipeline-from-goa skyhook
+# base (its reports/go-cam/02-filter.jsonl lists each model's status; "success"
+# == true GO-CAM). Override with a local dir / id-file / .jsonl, or set empty to
+# disable R1.
+TRUE_GOCAM_SOURCE ?= https://skyhook.geneontology.io/pipeline-from-goa/main
+# Parallel shards. Each worker loads its own GO ontology copy, so bound by RAM
+# (laptop ~4-8; a big fleet box can go higher). Resumable across runs.
+JOBS ?= 4
+
+# Fetch the corpus (shallow clone; ~2 GB working tree). No-op if it exists.
+$(NOCTUA_MODELS_DIR):
+	git clone --depth 1 $(NOCTUA_MODELS_REPO) $@
+.PHONY: corpus
+corpus: | $(NOCTUA_MODELS_DIR)
+	@echo "corpus ready: $(RATCHET_MODELS_DIR) ($$(find $(RATCHET_MODELS_DIR) -maxdepth 1 -name '*.ttl' | wc -l) models)"
+
+.PHONY: ratchet ratchet-smoke
+# Full corpus run. Resource-hungry (~55k models). Auto-fetches GO/RO and the
+# corpus if absent. Runs fine as a non-root user on a remote box: everything
+# writes under this checkout ($(RATCHET_OUT)) and the sibling corpus. Bound JOBS
+# by cores AND free RAM (each worker loads its own ~0.7 GB GO copy). R1 uses the
+# public skyhook URL by default -- override TRUE_GOCAM_SOURCE with a local path
+# on a host that mirrors skyhook. See README "Standard-Annotation Ratchet".
+ratchet: $(GO_ONTOLOGY) $(RO_ONTOLOGY) | $(NOCTUA_MODELS_DIR)
+	mkdir -p $(RATCHET_OUT)
+	python3 -m gocam_unwinder.ratchet \
+		--models-dir $(RATCHET_MODELS_DIR) \
+		--rules-dir rules \
+		--out-dir $(RATCHET_OUT) \
+		--go $(GO_ONTOLOGY) \
+		--ro $(RO_ONTOLOGY) \
+		--jobs $(JOBS) \
+		--skip-prefix SYNGO \
+		--skip-prefix R-HSA \
+		--skip-prefix YeastPathways \
+		$(if $(TRUE_GOCAM_SOURCE),--true-gocam-source $(TRUE_GOCAM_SOURCE),)
+
+# Build the shareable self-contained HTML dashboard from a ratchet run's output.
+# Reads $(RATCHET_OUT) (default: today's run) and writes dashboard.html beside it.
+# For a prior run: make ratchet-dashboard RATCHET_OUT=target_YYYYMMDD/ratchet
+.PHONY: ratchet-dashboard
+ratchet-dashboard: $(GROUPS_YAML)
+	python3 -m gocam_unwinder.ratchet.dashboard \
+		--out-dir $(RATCHET_OUT) \
+		--rules-dir rules \
+		--groups-yaml $(GROUPS_YAML) \
+		--output $(dir $(RATCHET_OUT))dashboard.html
+
+# Quick smoke run over the bundled test fixtures (no corpus download needed).
+ratchet-smoke: target/go_20250601.json
+	mkdir -p $(TARGET_DIR)/ratchet-smoke
+	python3 -m gocam_unwinder.ratchet \
+		--models-dir resources/test \
+		--rules-dir rules \
+		--out-dir $(TARGET_DIR)/ratchet-smoke \
+		--go target/go_20250601.json \
+		--ro resources/test/ro_20250723.owl \
+		--skip-prefix SYNGO \
+		--skip-prefix R-HSA
+
 # Clean up generated files
 clean:
 	rm -rf $(TARGET_DIR)

--- a/README.md
+++ b/README.md
@@ -75,3 +75,81 @@ python src/gocam_unwinder/gocam_ttl.py \
 ```
 
 This is useful when processing many models, as it prevents the statistics report from being mixed with the "Split evidence" progress messages.
+
+## Standard-Annotation Ratchet
+
+The `local/std-annot-ratchet` branch adds a two-level, monotonic pipeline that
+filters the whole [noctua-models](https://github.com/geneontology/noctua-models)
+corpus down to *standard annotations*, emitting a surviving set + a "what got
+filtered out" report at each stage, plus a self-contained, shareable HTML
+dashboard. Filtering rules live as data in `rules/`. Design, the rule inventory,
+and findings are in
+[`docs/plans/2026-06-25-standard-annotation-ratchet.md`](docs/plans/2026-06-25-standard-annotation-ratchet.md).
+
+### Running it over the full corpus
+
+This works as an ordinary, **non-root user** — on your laptop, or (for the ~55k
+model corpus) on a powerful box you can SSH into. Everything writes under your
+own checkout (`target_*/`) and a sibling `noctua-models/`; nothing needs a system
+install or elevated privileges.
+
+```bash
+# 0. Get a checkout (e.g. on the remote box you SSH into).
+git clone https://github.com/geneontology/go-cam-evidence-unwinder.git
+cd go-cam-evidence-unwinder
+
+# 1. A virtualenv in your own space, editable install.
+python3 -m venv env && . env/bin/activate
+pip install -r requirements.txt && pip install -e .
+
+# 2. Fetch the corpus (shallow clone, ~2 GB) as a sibling ../noctua-models.
+make corpus
+
+# 3. Run the ratchet, sharded. JOBS ~= cores minus headroom on a shared box.
+#    Auto-downloads the GO and RO ontologies on first run.
+make ratchet JOBS=8
+
+# 4. Build the shareable dashboard (auto-downloads groups.yaml).
+make ratchet-dashboard
+```
+
+Open `target_YYYYMMDD/dashboard.html` in a browser — it's a single self-contained
+file, so you can copy it off the remote host and share it as-is. For a quick,
+corpus-free sanity check, `make ratchet-smoke`.
+
+Notes for remote / restricted hosts:
+
+- **Sizing `JOBS`:** each shard worker loads its own ~0.7 GB GO copy, so pick
+  `JOBS` from the box's cores **and** free RAM. (A 96-core / 1 TiB host ran the
+  full corpus at `JOBS=48` in ~80 s.) Shards resume across runs via a `.done`
+  marker.
+- **R1 source:** "not a true GO-CAM" defaults to the public
+  `https://skyhook.geneontology.io/pipeline-from-goa/main`. On a host that mirrors
+  skyhook locally, skip the network by pointing at the local file:
+  `make ratchet TRUE_GOCAM_SOURCE=/path/to/pipeline-from-goa/main/reports/go-cam/02-filter.jsonl`.
+- **Existing corpus checkout:** set `NOCTUA_MODELS_DIR=/path/to/noctua-models`
+  instead of running `make corpus`.
+- **Any ordinary login account works:** run under your own account and stage the
+  checkout, venv, and `target_*/` outputs wherever you can write (`$HOME` or
+  `/tmp`). No root, `sudo`, or shared service account is needed.
+- **Driving it non-interactively (a script, or your own coding agent over SSH):**
+  the agent runs on your local machine and drives the remote host over SSH. On
+  your local machine, generate a dedicated, passphrase-less key just for this
+  (never a personal key) and authorize its public half on *your own* account on
+  the remote host:
+
+  ```bash
+  ssh-keygen -t ed25519 -N '' -C std-annot-ratchet-agent -f ~/.ssh/ratchet-agent
+  # then append ~/.ssh/ratchet-agent.pub to <you>@<host>:~/.ssh/authorized_keys
+  ```
+
+  Each remote command runs in a fresh non-login shell, so activate the venv in the
+  command itself:
+
+  ```bash
+  ssh -i ~/.ssh/ratchet-agent <you>@<host> \
+    'cd <checkout> && . env/bin/activate && make ratchet JOBS=48'
+  ```
+
+  Nothing about this is committed to the repo — only your key's public half lives
+  in your remote `~/.ssh/authorized_keys`.

--- a/docs/plans/2026-06-25-standard-annotation-ratchet.md
+++ b/docs/plans/2026-06-25-standard-annotation-ratchet.md
@@ -1,0 +1,557 @@
+# Standard-Annotation Ratchet Pipeline — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+> **Status:** LOCAL-ONLY work (branch `local/std-annot-ratchet`). Not to be pushed
+> upstream for now; may be PR'd later. Do not push or open a PR without explicit
+> instruction.
+>
+> **Progress:** **Tasks 1–8 done and green** (full suite **91 passed**, incl. the
+> 42 existing tests). The ratchet is runnable end to end:
+> `python -m gocam_unwinder.ratchet --jobs N` / `make ratchet[-smoke] JOBS=N`.
+> Built `src/gocam_unwinder/ratchet/{core,rules,runner,engine,model_rules,unit_rules,cli,summary,__main__}.py`;
+> a full `rules/` data set (5 model + 12 unit manifests, incl. 2 native `.rq`
+> SPARQL rules); `gocam_ttl.py` refactored into per-check callables + `classify=`;
+> parallel sharding (`--jobs N`, round-robin, ProcessPoolExecutor) with
+> shard-level resume and exact merge. Smoke over `resources/test`: 25 models → 23
+> (Phase A), 130 annotation units → 102 standard (Phase B); sharded `--jobs 4`
+> gives the identical result. **All planned tasks complete.**
+>
+> **First full corpus run (2026-06-25, `--jobs 48` on a 96-core host, ~78 s):**
+> 55,831 models → 46,071 candidate models (Phase A: −1,409 delete, −6,345 prefix,
+> −1,988 R1 true-GO-CAM, −18 edge-less) → 250,865 annotation units → **238,750
+> standard annotations** (Phase B; top filters: invalid_gp_cc_relation 7,288,
+> inconsistent_evidence 2,252; invalid_bp_cc/invalid_mf_bp removed 0). ~1.1 G of
+> per-stage manifests + reports.
+>
+> **Post-run additions (2026-06-25/26):** R1 wired to the live skyhook source
+> (see R1 note); a self-contained HTML **dashboard** with explorable model axes
+> (see *Dashboard* below), fed by a new per-model `model_stats.jsonl`. Full suite
+> **97 passed**.
+
+**Goal:** Build a two-level, monotonic "ratchet" mini-pipeline that takes the
+noctua-models corpus (S0) and reduces it, one rule at a time, to the set of
+*standard annotations* — emitting at each stage the surviving set (Sₙ) plus a
+report of what that rule filtered out.
+
+**Architecture:** Two phases. **Phase A (model-level)** applies cheap whole-model
+gates — `modelstate`, filename prefix, and **R1 "not-a-true-GO-CAM"** (consume
+pipeline-from-goa's published true-GO-CAM model-ID set) — to shrink the corpus
+fast. **Phase B (annotation-unit-level)** extracts annotation units from the
+surviving models and ratchets them through the existing 13 `gocam_ttl.py` checks,
+re-packaged as independently-runnable, cost-ordered rule stages. Rules are stored
+as a structured file set (`rules/NN-name/rule.yaml` + `query.rq` | python
+entrypoint); a thin runner walks them in order, reads the prior stage's survivors,
+and writes `Sₙ` survivors + `Sₙ` rejects + `reports/NN.jsonl`, then a roll-up
+summary. Engine is **per-file in-process rdflib** (supports both SPARQL `.rq` and
+Python predicates), reusing the existing `GoCamGraphBuilder` so ontology-aware
+checks stay cheap.
+
+**Tech Stack:** Python 3, rdflib (per-file parse + SPARQL 1.1), ontobio /
+GoAspector (GO aspect), the existing `src/gocam_unwinder/gocam_ttl.py`
+parsing + check logic, PyYAML rule manifests. No Blazegraph, no `arq`-per-file.
+
+**Affected Areas:** New importable subpackage `src/gocam_unwinder/ratchet/`
+(runner, rule loader, engine adapters); new top-level `rules/` data dir; small,
+additive refactor exposing the 13 checks as per-check callables in `gocam_ttl.py`;
+new `tests/`; a new `Makefile` ratchet target. Existing classification behavior is
+unchanged (additive only).
+
+---
+
+## Context
+
+This repo already determines, per annotation unit, whether it is a "standard
+annotation" (splittable: one evidence per edge) via `filter_out_non_std_annotations()`
+in `gocam_ttl.py`, running all 13 checks at once with no short-circuit. We want
+to lift that logic into a **staged, monotonic pipeline** mirroring the
+divide-and-conquer pattern in sibling repos `pipeline-from-goa` (numbered stage
+dirs, sibling reject dirs, per-stage `reports/NN.jsonl`, roll-up summary) and
+`noctua-models` (per-file SPARQL `.rq` QC, git-diff ratchet). The motivating
+property: each stage carries forward a *shrinking* survivor set, so later stages
+do strictly less work and the run gets faster as it proceeds.
+
+Key domain facts established during scoping (see `docs/plans/` discussion and
+CLAUDE.md rule docs):
+
+- **Two levels, not one.** "Standard annotation" is an *annotation-unit* concept
+  (a connected-component subgraph). "True GO-CAM" is a *whole-model* concept.
+  Per the chosen design, Phase A ratchets models, Phase B ratchets units.
+- **R1 = not-a-true-GO-CAM.** A True GO-CAM is a *production*, *pathway-like*
+  model (≥3 activities connected by causal / shared-chemical edges), classified
+  by `gocam-py/pipeline/filter_true_gocam_models.py`. By definition such a model
+  is not a flat standard annotation. We **consume** the published true-GO-CAM set
+  (pipeline-from-goa product `go-cams/json/`, ~2,008 model IDs; filename stem =
+  model ID) rather than recompute it.
+- **The expensive shared dependency** in Phase B is the connected-component
+  annotation partition (union-find over edges sharing individuals). Four checks
+  need it; everything else is per-edge.
+- **RO-dependent rules skip (not fail-open) when RO is absent** — must replicate.
+
+### Authoritative rule inventory (extracted; the prereq)
+
+Model gates (Phase A) + 13 numbered unit checks + 1 internal invariant (Phase B),
+in cost-tier order. TSV# is from the (never-committed) `std_annot_rules.tsv`,
+reproduced in `docs/plans/2026-06-05-remaining-std-annot-criteria-design.md`.
+
+| Phase / Stage | TSV# | Rule key | Category | Inputs | SPARQL feasibility |
+|---|---|---|---|---|---|
+| A · gate | — | `modelstate==delete` skip | model-gate | model graph | trivial |
+| A · gate | — | `skip_prefix` (SYNGO, R-HSA) | model-gate | filename | n/a |
+| A · gate (**R1**) | — | `not_true_gocam` | model-gate | published true-GO-CAM ID set | n/a (membership) |
+| B · 1 cheap | 15 | `edge_without_evidence` | evidence | none | ✅ trivial |
+| B · 1 cheap | 13 | `enabler_not_gp` | relation | GP allowlist | ⚠️ moderate |
+| B · 2 GO-aspect | 3 | `invalid_gp_cc_relation` | relation | GO + GP | ⚠️ moderate |
+| B · 2 GO-aspect | 6 | `invalid_mf_cc_relation` | relation | GO | ⚠️ moderate |
+| B · 2 GO-aspect | 10 | `invalid_bp_cc_relation` | relation | GO + anatomy | ⚠️ moderate |
+| B · 3 RO-closure | 1 | `mf_causal_mf` | relation | GO + RO:0002418 | ⚠️ moderate |
+| B · 3 RO-closure | 4 | `invalid_gp_bp_relation` | relation | GO + GP + RO:0002264 | ⚠️ moderate |
+| B · 3 RO-closure | 5 | `invalid_mf_bp_relation` | relation | GO + RO:0002264/0002418 | ⚠️ moderate |
+| B · 4 partition | 11 | `multiple_mf_bp` | cardinality | GO + RO | 🔶 partial |
+| B · 4 partition | 12 | `multiple_mf_anatomy` | cardinality | GO + anatomy | 🔶 partial |
+| B · 4 partition | 2 | `invalid_gp_mf_relation` | relation | GO + GP | ❌ hard |
+| B · 4 partition | — | `inconsistent_evidence` (internal) | evidence | none (grouping) | ❌ hard |
+| informational | 7/8/9 | non-root nesting MF→BP/MF→CC/BP→BP | — | — | no check (extensions) |
+
+## Constraints
+
+- **Local-only.** All work on branch `local/std-annot-ratchet`; never push / PR
+  without explicit instruction.
+- **Reuse, don't fork.** Phase B rules must call the existing check logic in
+  `gocam_ttl.py`, not reimplement it (the Hybrid decision). Ontology-aware checks
+  stay in Python; only new/simple structural rules may be authored as `.rq`.
+- **Monotonic.** Each stage reads *only* the prior stage's survivors; output sets
+  only shrink. A stage may never resurrect a removed item.
+- **Scale.** Must process ~55,831 models (~2 GB) without OOM: per-file streaming,
+  embarrassingly parallel by shard, checkpointed via a survivor manifest.
+- **Fidelity.** Per-unit rule verdicts must match `filter_out_non_std_annotations()`
+  on the existing fixtures (no semantic drift). RO-dependent rules skip when RO
+  absent.
+- **Engine.** Per-file in-process rdflib only. Do **not** load the corpus into
+  Blazegraph (it keeps the full journal hot and fights the shrink) and do **not**
+  spawn `arq` per (file, rule) (JVM startup × 55k × N).
+
+## Out of Scope
+
+- Recomputing true-GO-CAM classification ourselves (we consume the published set;
+  a local `gocam-py` recompute is a documented fallback only).
+- Rewriting the ontology-aware checks as SPARQL.
+- Blazegraph corpus loading / GPAD export.
+- Changing existing `gocam_ttl.py` classification semantics or the unwinder CLI.
+- Pushing, PR'ing, or any upstream publication (deferred).
+- Parallel-shard execution can land as a follow-up (Task 8) — single-process
+  correctness first.
+
+---
+
+## Tasks
+
+### Task 1: Rule manifest schema + ordered loader
+
+A rule lives in `rules/NN-name/` with a `rule.yaml`:
+
+```yaml
+id: edge_without_evidence      # stable key (matches failed_checks key where applicable)
+tsv: 15                         # std_annot_rules.tsv number, or null
+phase: unit                     # model | unit
+stage: 1                        # cost tier (ordering within phase)
+kind: python                    # python | sparql
+entrypoint: edge_without_evidence   # python: callable name in ratchet.unit_rules; sparql: query.rq present
+inputs: []                      # e.g. [go, ro, gp_allowlist, true_gocam_set]
+description: "Every GO-CAM relation edge must carry a lego:evidence triple."
+enabled: true
+```
+
+**Files:**
+- Create: `src/gocam_unwinder/ratchet/__init__.py`
+- Create: `src/gocam_unwinder/ratchet/rules.py` (`Rule` dataclass, `load_rules(rules_dir)`)
+- Create: `rules/00-model-modelstate/rule.yaml`, `rules/01-edge-without-evidence/rule.yaml` (seed fixtures)
+- Test: `tests/test_ratchet_rules.py`
+
+**Step 1: Write the failing test**
+
+```python
+def test_load_rules_ordered_and_parsed(tmp_path):
+    # Arrange: two rule dirs out of lexical order on disk
+    _write_rule(tmp_path / "rules" / "10-b", id="b", phase="unit", stage=2, kind="python")
+    _write_rule(tmp_path / "rules" / "00-a", id="a", phase="model", stage=0, kind="python")
+
+    # Act
+    rules = load_rules(tmp_path / "rules")
+
+    # Assert: ordered by dir prefix; fields parsed
+    assert [r.id for r in rules] == ["a", "b"]
+    assert rules[0].phase == "model" and rules[1].kind == "python"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_ratchet_rules.py::test_load_rules_ordered_and_parsed -v`
+Expected: FAIL with `ImportError`/`ModuleNotFoundError` for `ratchet.rules`.
+
+**Step 3: Write minimal implementation**
+
+`Rule` dataclass with the yaml fields; `load_rules()` globs `*/rule.yaml`, sorts
+by parent dir name, parses with PyYAML, validates `phase`/`kind` enums, returns a
+list. SPARQL rules require a sibling `query.rq`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_ratchet_rules.py -v` — Expected: PASS
+
+---
+
+### Task 2: Ratchet runner core (the staging engine)
+
+Generic over phase: given an input *set* (a manifest of survivor IDs + their
+backing files) and a rule, partition into survivors / rejects, materialize
+`SNN-<id>/` (survivors), `SNN-<id>.rejects.tsv`, and `reports/NN.jsonl`.
+
+**Files:**
+- Create: `src/gocam_unwinder/ratchet/runner.py` (`Stage`, `run_stage`, `Manifest`)
+- Test: `tests/test_ratchet_runner.py`
+
+**Step 1: Write the failing test**
+
+```python
+def test_run_stage_partitions_and_reports(tmp_path):
+    # Arrange: a 4-item set + a trivial rule "keep ids that don't start with X"
+    manifest = Manifest.of(["a1", "a2", "X3", "X4"])
+    rule = _trivial_reject_rule(predicate=lambda item_id: item_id.startswith("X"),
+                                reason="starts_with_X")
+
+    # Act
+    out = run_stage(rule, manifest, out_dir=tmp_path, stage_index=1)
+
+    # Assert: survivors shrink, rejects + report record the reason
+    assert out.survivors.ids == ["a1", "a2"]
+    assert out.rejected_ids == ["X3", "X4"]
+    report = _read_jsonl(tmp_path / "reports" / "01-starts_with_X.jsonl")
+    assert {r["id"]: r["decision"] for r in report} == {
+        "a1": "keep", "a2": "keep", "X3": "remove", "X4": "remove"}
+    assert all(r["reason"] == "starts_with_X" for r in report if r["decision"] == "remove")
+```
+
+**Step 2: Run test to verify it fails** — Expected: FAIL (`run_stage` undefined).
+
+**Step 3: Write minimal implementation**
+
+`run_stage` iterates the input manifest, calls `rule.apply(item) -> Verdict(keep,
+reason, detail)`, writes survivors manifest + rejects.tsv + jsonl, returns a
+`StageResult`. Monotonic invariant asserted: `survivors ⊆ input`.
+
+**Step 4: Run test to verify it passes** — Expected: PASS
+
+---
+
+### Task 3: Engine adapters — Python rule + SPARQL rule
+
+Two `rule.apply` strategies behind one `Verdict` interface, both over a per-file
+rdflib graph (lazily parsed, cached per item within a stage).
+
+**Files:**
+- Create: `src/gocam_unwinder/ratchet/engine.py` (`PythonRuleAdapter`, `SparqlRuleAdapter`)
+- Test: `tests/test_ratchet_engine.py`
+
+**Step 1: Write the failing test**
+
+```python
+def test_sparql_ask_rule_removes_on_match(tmp_path, edgeless_model_ttl):
+    # ASK that is TRUE when the model has an OBO-namespace edge with no evidence
+    rule = SparqlRuleAdapter(query_path=EDGE_NO_EV_RQ, remove_when="ask_true",
+                             reason="edge_without_evidence")
+    verdict = rule.apply(_item(edgeless_model_ttl))
+    assert verdict.keep is False and verdict.reason == "edge_without_evidence"
+
+def test_python_rule_uses_existing_check(monkeypatch, mgi_model_item):
+    rule = PythonRuleAdapter(callable_=lambda ctx, item: Verdict.keep_all(),
+                             reason="noop")
+    assert rule.apply(mgi_model_item).keep is True
+```
+
+**Step 2: Run test to verify it fails** — Expected: FAIL.
+
+**Step 3: Write minimal implementation**
+
+- `SparqlRuleAdapter`: `rdflib.Graph().parse(item.path)`, run ASK/SELECT, map
+  result to keep/remove per `remove_when`.
+- `PythonRuleAdapter`: call a callable `(ctx, item) -> Verdict`, where `ctx`
+  carries the shared `GoCamGraphBuilder` (GO/RO loaded once).
+
+**Step 4: Run test to verify it passes** — Expected: PASS
+
+---
+
+### Task 4: Phase A model-level rules
+
+**Files:**
+- Create: `src/gocam_unwinder/ratchet/model_rules.py`
+- Create: `rules/00-model-modelstate/`, `rules/01-model-skip-prefix/`,
+  `rules/02-model-not-true-gocam/` (+ `rule.yaml`s)
+- Test: `tests/test_ratchet_model_rules.py`
+
+**Step 1: Write the failing tests**
+
+```python
+def test_modelstate_delete_removed(delete_state_item, prod_item):
+    assert modelstate_gate(ctx=None, item=delete_state_item).keep is False
+    assert modelstate_gate(ctx=None, item=prod_item).keep is True
+
+def test_skip_prefix_removes_syngo_and_rhsa(item_named):
+    gate = make_skip_prefix_gate(["SYNGO", "R-HSA"])
+    assert gate(None, item_named("SYNGO_5371.ttl")).keep is False
+    assert gate(None, item_named("MGI_MGI_1100089.ttl")).keep is True
+
+def test_not_true_gocam_consumes_id_set(item_named, true_gocam_ids):
+    # true_gocam_ids loaded from a fixture list (filename stems)
+    gate = make_not_true_gocam_gate(true_gocam_ids={"605c...01"})
+    assert gate(None, item_named("605c...01.ttl")).keep is False   # is a true GO-CAM -> removed
+    assert gate(None, item_named("MGI_MGI_1100089.ttl")).keep is True
+```
+
+**Step 2: Run test to verify it fails** — Expected: FAIL.
+
+**Step 3: Write minimal implementation**
+
+- `modelstate_gate`: reuse `GoCamGraph.get_modelstate()`; remove if `== "delete"`.
+- `make_skip_prefix_gate(prefixes)`: filename `startswith`.
+- `make_not_true_gocam_gate(true_gocam_ids)`: remove if `item.model_id_stem in
+  true_gocam_ids`. The ID set is loaded by `load_true_gocam_ids(source)`, which
+  accepts the published skyhook base URL (default
+  `https://skyhook.geneontology.io/pipeline-from-goa/main` →
+  `reports/go-cam/02-filter.jsonl`, `status == "success"`), a `.jsonl` report, a
+  local dir of `*.json` stems, or a newline id file. **Resolved** (see Notes).
+
+**Step 4: Run test to verify it passes** — Expected: PASS
+
+---
+
+### Task 5: Phase B unit rules — expose the 13 checks as per-check callables
+
+Additive refactor: split `filter_out_non_std_annotations()` so each check is a
+standalone function `check_<key>(builder, annotation) -> set[bnode_id]` (the edges
+it flags), and have the existing method call them in a loop (behavior preserved).
+Then wrap each as a unit Rule whose `apply` removes an annotation unit if the check
+flags ≥1 of its edges.
+
+**Files:**
+- Modify: `src/gocam_unwinder/gocam_ttl.py` (extract per-check callables; keep
+  `filter_out_non_std_annotations()` delegating to them — no semantic change)
+- Create: `src/gocam_unwinder/ratchet/unit_rules.py` (adapters mapping each check
+  to a `Verdict` over an annotation unit)
+- Create: `rules/1x-*/`..`rules/4x-*/` rule.yaml per check, staged by cost tier
+- Test: `tests/test_ratchet_unit_rules.py`
+
+**Step 1: Write the failing test**
+
+```python
+@pytest.mark.parametrize("model,check_key,expect_fail", [
+    ("66c7d41500000016.ttl", "edge_without_evidence", True),
+    ("MGI_MGI_1100089.ttl",  "edge_without_evidence", False),
+    ("5b318d0900000481.ttl", "mf_causal_mf",          True),   # needs RO
+    ("enabler_not_gp_example.ttl", "enabler_not_gp",  True),
+])
+def test_unit_rule_matches_existing_classification(builder_with_ro, model, check_key, expect_fail):
+    units = parse_units(builder_with_ro, RES / model)
+    verdicts = [unit_rule(check_key).apply(_unit_item(u)) for u in units]
+    any_removed = any(v.keep is False for v in verdicts)
+    assert any_removed == expect_fail
+```
+
+**Step 2: Run test to verify it fails** — Expected: FAIL (`unit_rule` undefined /
+checks not yet extracted).
+
+**Step 3: Write minimal implementation**
+
+Extract each check block into `check_<key>()`; build `unit_rule(key)` mapping to
+the right callable + reason; RO-dependent rules return `Verdict.skip()` (keep,
+not flag) when `builder.ro_ontology is None`, replicating current gating.
+
+**Step 4: Run test to verify it passes** — Expected: PASS
+
+**Step 5: Run full test suite for regressions**
+
+Run: `pytest -v` — Expected: all existing `gocam_ttl` tests still PASS (refactor
+is behavior-preserving).
+
+---
+
+### Task 6: Two native `.rq` SPARQL rules (prove the hybrid path)
+
+Author `edge_without_evidence` as a portable `.rq` ASK (it is the one trivial
+case), and port `noctua-models/sparql/check-disconnected-individuals.rq` as an
+example structural rule, to demonstrate `.rq` rules run under the same runner.
+
+**Files:**
+- Create: `rules/01-edge-without-evidence/query.rq` (kind: sparql variant)
+- Create: `rules/90-disconnected-individuals/query.rq` + `rule.yaml`
+- Test: `tests/test_ratchet_sparql_rules.py`
+
+**Step 1: Write the failing test**
+
+```python
+def test_sparql_edge_without_evidence_matches_python(no_ev_item, ev_item):
+    rq = SparqlRuleAdapter(EDGE_NO_EV_RQ, remove_when="ask_true",
+                           reason="edge_without_evidence")
+    assert rq.apply(no_ev_item).keep is False
+    assert rq.apply(ev_item).keep is True
+```
+
+**Step 2–4:** Standard TDD cycle; the `.rq` mirrors the Python check’s OBO-namespace
+edge filter.
+
+---
+
+### Task 7: Runner CLI + roll-up report + two-level wiring + Makefile
+
+Chain Phase A → surviving models → Phase B over those; emit a roll-up summary
+(per-stage in/out counts + cumulative shrink) and a Makefile target writing to
+`target_ratchet_$(date +%Y%m%d)/`.
+
+**Files:**
+- Create: `src/gocam_unwinder/ratchet/cli.py` (`python -m gocam_unwinder.ratchet
+  --models-dir … --rules-dir rules --out-dir target_ratchet_YYYYMMDD
+  --true-gocam-dir … [--ro …] [--go …]`)
+- Create: `src/gocam_unwinder/ratchet/summary.py` (merge `reports/*.jsonl` → TSV/MD)
+- Modify: `Makefile` (add `ratchet` target)
+- Test: `tests/test_ratchet_end_to_end.py`
+
+**Step 1: Write the failing integration test**
+
+```python
+def test_end_to_end_two_level_shrink(tmp_path, fixture_models_dir):
+    result = run_ratchet(models_dir=fixture_models_dir, rules_dir=RULES,
+                         out_dir=tmp_path, go=GO_JSON, ro=RO_OWL,
+                         true_gocam_ids={"R-HSA-9937080"})
+    # Phase A removed the true-GO-CAM + delete-state models
+    assert "R-HSA-9937080" not in result.phase_a_survivors
+    # Monotonic: every stage count <= previous
+    counts = [s.in_count for s in result.stages] + [result.stages[-1].out_count]
+    assert counts == sorted(counts, reverse=True)
+    # Roll-up summary exists and lists every stage
+    assert (tmp_path / "summary.tsv").exists()
+```
+
+**Step 2: Run test to verify it fails** — Expected: FAIL.
+
+**Step 3: Write implementation** — wire phases, summary, CLI, Makefile target.
+
+**Step 4–5:** Run integration test, then `pytest -v` for full regression.
+
+---
+
+### Task 8 (follow-up): resume + parallel sharding
+
+Checkpoint the survivor manifest per stage (skip completed stages on rerun);
+shard the Phase B input across workers (`--jobs N`), merging per-shard
+survivor/reject manifests. Deferred until single-process correctness is proven.
+
+---
+
+## Verification
+
+```bash
+# Full test suite (new ratchet tests + existing gocam_ttl regression)
+pytest -v
+
+# Smoke test over the bundled fixtures (no corpus download needed)
+python -m gocam_unwinder.ratchet \
+  --models-dir resources/test \
+  --rules-dir rules \
+  --out-dir /tmp/ratchet-smoke \
+  --go target/go_20250601.json \
+  --ro resources/test/ro_20250723.owl \
+  --true-gocam-ids R-HSA-9937080
+
+# Inspect the ratchet: each stage's survivors shrink; rejects carry reasons
+column -t -s$'\t' /tmp/ratchet-smoke/summary.tsv
+head /tmp/ratchet-smoke/reports/*.jsonl
+```
+
+**Expected final state:**
+- [ ] All tests pass; existing `gocam_ttl` tests unchanged (behavior-preserving refactor).
+- [ ] Per-unit rule verdicts match `filter_out_non_std_annotations()` on every fixture.
+- [ ] Two-level run: Phase A shrinks models, Phase B shrinks units over survivors.
+- [ ] Each stage emits survivors + rejects + `reports/NN.jsonl`; roll-up `summary.tsv` lists all stages with monotonically non-increasing counts.
+- [ ] R1 consumes an external true-GO-CAM ID set (dir/file now; URL fallback documented).
+- [ ] Rules are pure data in `rules/`; adding a rule needs no runner change.
+
+---
+
+## Notes
+
+- **Behavior-preserving refactor first (Task 5).** The extraction of per-check
+  callables must not change `filter_out_non_std_annotations()` output — keep it
+  delegating. Run the existing suite before/after.
+- **Cardinality + exemption checks (#11/#12/#2) and `inconsistent_evidence`** need
+  the whole annotation unit, not a single edge — they live in Phase B stage 4 and
+  operate on the unit the runner hands them; they cannot be authored as `.rq`.
+- **RO gating:** `mf_causal_mf`, `invalid_gp_bp_relation`, `invalid_mf_bp_relation`
+  must be *skipped* (item kept) when no RO is loaded — do not fail-open to "remove".
+- **R1 sourcing — RESOLVED.** `--true-gocam-source` consumes the published
+  pipeline-from-goa skyhook base (default
+  `https://skyhook.geneontology.io/pipeline-from-goa/main`); `load_true_gocam_ids`
+  appends `reports/go-cam/02-filter.jsonl` and keeps `status == "success"` ids
+  (2,137 true GO-CAMs; `model_id` is the bare stem, matching our `.ttl` stems).
+  Verified live. Also accepts a local dir / id-file / `.jsonl`. A browser-like
+  User-Agent is required (skyhook is Cloudflare-fronted; default `Python-urllib`
+  gets a 403). Local recompute via `gocam-py/pipeline/filter_true_gocam_models.py`
+  remains a fallback if the published set is unavailable.
+- **Monotonic invariant** is the correctness backbone: assert `survivors ⊆ input`
+  in `run_stage`; the roll-up must show non-increasing counts.
+- **Engine choice rationale** (do not revisit lightly): per-file rdflib is
+  embarrassingly parallel and the shrinking survivor set directly reduces later
+  work; Blazegraph keeps the full 2 GB journal hot regardless and fights the
+  shrink; `arq`-per-file pays JVM startup × 55k × N. See
+  `noctua-models/Makefile` (blazegraph) and `.github/workflows/check-models.yml`
+  (arq) for the patterns we are deliberately *not* using at scale.
+- **Reference patterns worth reading:** `pipeline-from-goa/scripts/gocam-processing.sh`
+  (numbered stage dirs `01-…→05-…`, sibling reject dir `--pseudo-gocam-output-dir`,
+  per-stage `reports/NN.jsonl`, roll-up `generate_log_summary.py`);
+  `noctua-models/sparql/*.rq` (the `.rq` rule template: SELECT-DISTINCT violation
+  enumerator, model-header attribution join, edges in both direct + reified form).
+
+## Running at corpus scale
+
+The full corpus (~55,831 TTLs, ~2 GB) is resource-hungry, so it's worth running on
+a machine with many cores and ample RAM. It runs as an ordinary, non-root user —
+the **generic, reproducible recipe** (`make corpus && make ratchet JOBS=N && make
+ratchet-dashboard`, with the corpus / ontologies / groups.yaml auto-fetched and R1
+via the public skyhook URL) is in the README's "Standard-Annotation Ratchet"
+section, along with notes on sizing `JOBS` and driving the run non-interactively
+over SSH.
+
+- **Sizing `N`:** bounded by cores **and** RAM, since each worker loads its own
+  ~0.7 GB GO copy. A 96-core / ~1 TiB host ran the whole corpus at `--jobs 48` in
+  ~78 s.
+- **GOTCHA — shard resume vs. fresh output:** each shard writes a `.done` marker,
+  so re-running to the *same* `--out-dir` returns cached stage stats and does NOT
+  regenerate per-item files. After a code change that adds/alters outputs (e.g.
+  adding `model_stats.jsonl`), delete the out-dir first to force a fresh run.
+
+## Dashboard (stats suite)
+
+`gocam_unwinder.ratchet.dashboard` turns a run's `summary.tsv` + `rejects/*.tsv` +
+`model_stats.jsonl` (+ `rules/` for descriptions, `groups.yaml` for group labels)
+into ONE self-contained `dashboard.html` — data embedded inline, no external
+libs/network, shareable by sending the file. `make ratchet-dashboard
+RATCHET_OUT=<out>`.
+
+Shows: the two-phase funnel (green/red shrink bars); a per-rule drill-down of the
+top offending `predicate → target` patterns (example-model chips deep-link into
+the Noctua editor); and **explorable model axes** — toggle by modelstate or
+editorial group (providedBy resolved via groups.yaml), per-bucket models /
+passing / unit pass-rate, a per-model percent-passing histogram, and a model list
+linking to `<noctua_base>gomodel:<id>`. All tables are click-to-sort.
+
+- Per-model stats come from `model_stats.jsonl` (one row per Phase B model:
+  modelstate, raw providedBy group URIs, title, total/passing units), emitted by
+  `cli._run_phase_b` and merged across shards. Group URI→label resolution happens
+  at dashboard-build time, so the *run* needs no `groups.yaml`.
+- Noctua editor URL form is `…/editor/graph/gomodel:<id>` (verified in the
+  `noctua` repo); base is `--noctua-base` (default `noctua.geneontology.org`).
+- **Findings (2026-06-25):** 44,454 / 46,071 candidate models pass (96.5%); 39,625
+  are 100 % standard; production 45,330 / development 637; MGI 26,949 / ZFIN 10,129
+  / SGD 7,832. The dominant unit filter `invalid_gp_cc_relation` (7,288) is
+  overwhelmingly gene-products joined to protein complexes via `part_of` instead
+  of `located_in` — a real curation signal.

--- a/rules/00-model-modelstate/rule.yaml
+++ b/rules/00-model-modelstate/rule.yaml
@@ -1,0 +1,10 @@
+id: modelstate_delete
+phase: model
+stage: 0
+kind: python
+entrypoint: modelstate_gate
+inputs: []
+description: >-
+  Drop whole models whose lego:modelstate is "delete"; such models are never
+  classified. Cheapest possible Phase A gate (a single model-level triple).
+enabled: true

--- a/rules/01-model-skip-prefix/rule.yaml
+++ b/rules/01-model-skip-prefix/rule.yaml
@@ -1,0 +1,11 @@
+id: skip_prefix
+phase: model
+stage: 0
+kind: python
+entrypoint: skip_prefix_gate
+inputs: [skip_prefixes]
+description: >-
+  Drop whole models whose filename starts with a configured prefix (e.g. SYNGO,
+  R-HSA for Reactome imports). Filename-only test; no graph parse. A no-op when
+  no prefixes are configured.
+enabled: true

--- a/rules/02-model-not-true-gocam/rule.yaml
+++ b/rules/02-model-not-true-gocam/rule.yaml
@@ -1,0 +1,13 @@
+id: not_true_gocam
+phase: model
+stage: 0
+kind: python
+entrypoint: not_true_gocam_gate
+inputs: [true_gocam_set]
+description: >-
+  R1: a true GO-CAM -- a production, pathway-like model (a path of >=3 activities
+  connected by causal / shared-chemical edges) -- cannot be a standard annotation
+  by definition. Removes models whose id is in the consumed true-GO-CAM set
+  (pipeline-from-goa go-cams/json product). Membership test on the model id; no
+  graph parse. A no-op when no set is supplied.
+enabled: true

--- a/rules/03-model-has-activity-edges/query.rq
+++ b/rules/03-model-has-activity-edges/query.rq
@@ -1,0 +1,12 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+
+# TRUE when the model has at least one GO-CAM relation edge: an OBO-namespace
+# (BFO/RO) reified owl:Axiom. With remove_when: ask_false the model is removed
+# when this is FALSE -- i.e. it has no activity edges to contribute.
+ASK {
+  ?ax a owl:Axiom ;
+      owl:annotatedSource ?s ;
+      owl:annotatedProperty ?p ;
+      owl:annotatedTarget ?t .
+  FILTER(STRSTARTS(STR(?p), "http://purl.obolibrary.org/obo/"))
+}

--- a/rules/03-model-has-activity-edges/rule.yaml
+++ b/rules/03-model-has-activity-edges/rule.yaml
@@ -1,0 +1,11 @@
+id: model_has_activity_edges
+phase: model
+stage: 0
+kind: sparql
+remove_when: ask_false
+inputs: []
+description: >-
+  Drop degenerate models that contain no GO-CAM activity edge at all (no
+  OBO-namespace reified owl:Axiom). Such a model yields zero annotation units, so
+  it cannot contribute a standard annotation. SPARQL ASK; no ontology needed.
+enabled: true

--- a/rules/04-model-disconnected-individuals/query.rq
+++ b/rules/04-model-disconnected-individuals/query.rq
@@ -1,0 +1,17 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+
+# One row per disconnected owl:NamedIndividual: an individual with no incoming
+# AND no outgoing connection to another named individual, counting both direct
+# triples and reified owl:Axiom edges. Adapted from noctua-models
+# sparql/check-disconnected-individuals.rq. remove_when: select_nonempty.
+SELECT DISTINCT ?individual WHERE {
+  ?individual a owl:NamedIndividual .
+  # no outgoing direct edge to another named individual
+  MINUS { ?individual ?p1 ?o1 . ?o1 a owl:NamedIndividual . }
+  # no incoming direct edge from another named individual
+  MINUS { ?s2 ?p2 ?individual . ?s2 a owl:NamedIndividual . }
+  # not the source of a reified edge
+  MINUS { ?ax3 owl:annotatedSource ?individual . }
+  # not the target of a reified edge
+  MINUS { ?ax4 owl:annotatedTarget ?individual . }
+}

--- a/rules/04-model-disconnected-individuals/rule.yaml
+++ b/rules/04-model-disconnected-individuals/rule.yaml
@@ -1,0 +1,14 @@
+id: model_disconnected_individuals
+phase: model
+stage: 0
+kind: sparql
+remove_when: select_nonempty
+inputs: []
+description: >-
+  OPTIONAL QC example (disabled by default). Ported from noctua-models
+  sparql/check-disconnected-individuals.rq: enumerates owl:NamedIndividuals with
+  no incoming or outgoing connection to another individual (counting direct and
+  reified edges). Demonstrates the SELECT-style .rq path; enable to drop
+  malformed models. Note: evidence individuals can read as disconnected, so this
+  is intentionally off by default.
+enabled: false

--- a/rules/11-edge-without-evidence/rule.yaml
+++ b/rules/11-edge-without-evidence/rule.yaml
@@ -1,0 +1,11 @@
+id: edge_without_evidence
+phase: unit
+stage: 1
+tsv: 15
+kind: python
+entrypoint: unit_edge_without_evidence
+inputs: []
+description: >-
+  Every GO-CAM relation edge in the annotation must carry a lego:evidence
+  triple.
+enabled: true

--- a/rules/12-enabler-not-gp/rule.yaml
+++ b/rules/12-enabler-not-gp/rule.yaml
@@ -1,0 +1,11 @@
+id: enabler_not_gp
+phase: unit
+stage: 1
+tsv: 13
+kind: python
+entrypoint: unit_enabler_not_gp
+inputs: [gp_allowlist]
+description: >-
+  The enabler (target of an enabled_by edge) must be a gene product, not a GO
+  term / ChEBI / other entity.
+enabled: true

--- a/rules/21-invalid-gp-cc-relation/rule.yaml
+++ b/rules/21-invalid-gp-cc-relation/rule.yaml
@@ -1,0 +1,11 @@
+id: invalid_gp_cc_relation
+phase: unit
+stage: 2
+tsv: 3
+kind: python
+entrypoint: unit_invalid_gp_cc_relation
+inputs: [go, gp_allowlist]
+description: >-
+  A gene product connected to a non-root cellular component must use
+  located_in (RO:0001025).
+enabled: true

--- a/rules/22-invalid-mf-cc-relation/rule.yaml
+++ b/rules/22-invalid-mf-cc-relation/rule.yaml
@@ -1,0 +1,11 @@
+id: invalid_mf_cc_relation
+phase: unit
+stage: 2
+tsv: 6
+kind: python
+entrypoint: unit_invalid_mf_cc_relation
+inputs: [go]
+description: >-
+  A root molecular function connected to a non-root cellular component must
+  use is_active_in (RO:0002432).
+enabled: true

--- a/rules/23-invalid-bp-cc-relation/rule.yaml
+++ b/rules/23-invalid-bp-cc-relation/rule.yaml
@@ -1,0 +1,11 @@
+id: invalid_bp_cc_relation
+phase: unit
+stage: 2
+tsv: 10
+kind: python
+entrypoint: unit_invalid_bp_cc_relation
+inputs: [go, anatomy]
+description: >-
+  A biological process connected to a cellular component or anatomy term must
+  use occurs_in (BFO:0000066).
+enabled: true

--- a/rules/31-mf-causal-mf/rule.yaml
+++ b/rules/31-mf-causal-mf/rule.yaml
@@ -1,0 +1,11 @@
+id: mf_causal_mf
+phase: unit
+stage: 3
+tsv: 1
+kind: python
+entrypoint: unit_mf_causal_mf
+inputs: [go, ro]
+description: >-
+  A causal relation (RO:0002418 family) connecting two molecular functions is
+  not allowed. Skipped without RO.
+enabled: true

--- a/rules/32-invalid-gp-bp-relation/rule.yaml
+++ b/rules/32-invalid-gp-bp-relation/rule.yaml
@@ -1,0 +1,11 @@
+id: invalid_gp_bp_relation
+phase: unit
+stage: 3
+tsv: 4
+kind: python
+entrypoint: unit_invalid_gp_bp_relation
+inputs: [go, gp_allowlist, ro]
+description: >-
+  A gene product connected to any biological process must use the
+  acts_upstream_of_or_within (RO:0002264) family. Skipped without RO.
+enabled: true

--- a/rules/33-invalid-mf-bp-relation/rule.yaml
+++ b/rules/33-invalid-mf-bp-relation/rule.yaml
@@ -1,0 +1,12 @@
+id: invalid_mf_bp_relation
+phase: unit
+stage: 3
+tsv: 5
+kind: python
+entrypoint: unit_invalid_mf_bp_relation
+inputs: [go, ro]
+description: >-
+  A root molecular function connected to a non-root biological process must
+  use part_of, the acts_upstream (RO:0002264) family, or the causal
+  (RO:0002418) family. Skipped without RO.
+enabled: true

--- a/rules/41-multiple-mf-bp/rule.yaml
+++ b/rules/41-multiple-mf-bp/rule.yaml
@@ -1,0 +1,11 @@
+id: multiple_mf_bp
+phase: unit
+stage: 4
+tsv: 11
+kind: python
+entrypoint: unit_multiple_mf_bp
+inputs: [go, ro]
+description: >-
+  An annotation may contain at most one MF->BP edge (over part_of /
+  acts_upstream / causal relations).
+enabled: true

--- a/rules/42-multiple-mf-anatomy/rule.yaml
+++ b/rules/42-multiple-mf-anatomy/rule.yaml
@@ -1,0 +1,11 @@
+id: multiple_mf_anatomy
+phase: unit
+stage: 4
+tsv: 12
+kind: python
+entrypoint: unit_multiple_mf_anatomy
+inputs: [go, anatomy]
+description: >-
+  An annotation may contain at most one MF->anatomical-structure edge (GO CC
+  or anatomy-ontology term).
+enabled: true

--- a/rules/43-invalid-gp-mf-relation/rule.yaml
+++ b/rules/43-invalid-gp-mf-relation/rule.yaml
@@ -1,0 +1,12 @@
+id: invalid_gp_mf_relation
+phase: unit
+stage: 4
+tsv: 2
+kind: python
+entrypoint: unit_invalid_gp_mf_relation
+inputs: [go, gp_allowlist]
+description: >-
+  GP<->MF backbone relation validity: enabled_by (MF source) or contributes_to
+  (MF target); has_input/has_output allowed MF->GP extensions. One valid
+  backbone exempts the rest.
+enabled: true

--- a/rules/44-inconsistent-evidence/rule.yaml
+++ b/rules/44-inconsistent-evidence/rule.yaml
@@ -1,0 +1,11 @@
+id: inconsistent_evidence
+phase: unit
+stage: 4
+tsv: null
+kind: python
+entrypoint: unit_inconsistent_evidence
+inputs: []
+description: >-
+  In a multi-edge annotation, every evidence-metadata group must contain
+  exactly one evidence from each edge (so it splits cleanly).
+enabled: true

--- a/rules/README.md
+++ b/rules/README.md
@@ -1,0 +1,42 @@
+# Ratchet rules
+
+Each subdirectory is one rule in the standard-annotation ratchet. The runner
+(`gocam_unwinder.ratchet`) discovers them and applies them **in directory-name
+order** — the zero-padded `NN-` prefix makes lexical order equal execution order.
+Adding a rule needs no code change to the runner; only `kind: python` rules need
+a registered entrypoint.
+
+## Layout
+
+```
+rules/
+  00-model-modelstate/      rule.yaml                 (Phase A, python)
+  01-edge-without-evidence/ rule.yaml  query.rq       (Phase B, sparql)
+  ...
+```
+
+## `rule.yaml` fields
+
+| field         | required | meaning |
+|---------------|----------|---------|
+| `id`          | yes | stable rule key (matches a `failed_checks` key where one exists); used in reports + output filenames |
+| `phase`       | yes | `model` (Phase A, whole-model) or `unit` (Phase B, annotation unit) |
+| `kind`        | yes | `python` (registered predicate) or `sparql` (sibling `query.rq`) |
+| `stage`       | no  | cost tier; ordering hint within a phase (default 0) |
+| `tsv`         | no  | `std_annot_rules.tsv` number, if any |
+| `entrypoint`  | python only | callable name in the rule registry, signature `(ctx, item) -> Verdict` |
+| `remove_when` | sparql only | `ask_true` (default) \| `ask_false` \| `select_nonempty` |
+| `inputs`      | no  | declared deps, e.g. `[go, ro, gp_allowlist, true_gocam_set]` |
+| `description` | no  | human-readable; surfaced in the roll-up report |
+| `enabled`     | no  | set `false` to skip the rule without deleting it (default `true`) |
+
+## Engine
+
+Rules run **per model file, in-process with rdflib** — no Blazegraph, no `arq`
+subprocess. SPARQL rules are plain SPARQL 1.1 and stay engine-portable (they run
+unchanged under rdflib, arq, or Blazegraph), following the `noctua-models/sparql/*.rq`
+template. Ontology-aware checks (GO aspect, RO closure) are `kind: python` and
+reuse the existing `gocam_ttl` logic via the shared `ctx` (a `GoCamGraphBuilder`).
+
+See `docs/plans/2026-06-25-standard-annotation-ratchet.md` for the full rule
+inventory and design.

--- a/src/gocam_unwinder/gocam_ttl.py
+++ b/src/gocam_unwinder/gocam_ttl.py
@@ -1056,7 +1056,7 @@ class GoCamGraphBuilder:
 
         return primary
 
-    def parse_ttl(self, ttl_filename):
+    def parse_ttl(self, ttl_filename, classify=True):
         gocam = GoCamGraph()
         gocam.g.parse(ttl_filename, format="ttl")
         gocam.model_id = gocam.get_model_id()
@@ -1070,140 +1070,187 @@ class GoCamGraphBuilder:
             gocam.groups = group_uris
         gocam.standard_annotations = []
         gocam.extract_standard_annotations()
-        gocam = self.filter_out_non_std_annotations(gocam)
+        if classify:
+            gocam = self.filter_out_non_std_annotations(gocam)
         return gocam
+
+    # ------------------------------------------------------------------
+    # Per-check callables (ratchet Task 5). Each takes (gcg, sa) and returns
+    # the set of edge bnode_ids the check flags within a single
+    # StandardAnnotation; an empty set means the check passed.
+    # filter_out_non_std_annotations() assembles these into failed_checks.
+    # Splitting them out is BEHAVIOR-PRESERVING: run_all_checks() reproduces the
+    # original inline logic exactly (the existing test suite is the guard).
+    # ------------------------------------------------------------------
+
+    def check_inconsistent_evidence(self, gcg, sa):
+        """Multi-edge annotations: evidence must be consistent across edges."""
+        if not gcg.has_consistent_evidence_across_edges(sa):
+            return set(sa.edges.keys())
+        return set()
+
+    def check_multiple_mf_bp(self, gcg, sa):
+        """#11: at most one MF->BP edge (over self.mf_bp_valid_relations)."""
+        mf_bp_edges = [
+            edge for edge in sa.edges.values()
+            if self._go_aspect(edge.source_type, gcg.g) == "MF"
+            and self._go_aspect(edge.target_type, gcg.g) == "BP"
+            and str(edge.property_uri) in self.mf_bp_valid_relations
+        ]
+        if len(mf_bp_edges) > 1:
+            return {e.bnode_id for e in mf_bp_edges}
+        return set()
+
+    def check_mf_causal_mf(self, gcg, sa):
+        """#1 (RO): causal relation between two MF nodes. Empty without RO."""
+        flagged = set()
+        if self.causal_relations:
+            for edge in sa.edges.values():
+                if (self.uri_is_causal_relation(edge.property_uri) and
+                        self.uri_is_molecular_function(edge.source_type) and
+                        self.uri_is_molecular_function(edge.target_type)):
+                    flagged.add(edge.bnode_id)
+        return flagged
+
+    def check_edge_without_evidence(self, gcg, sa):
+        """#15: every edge must carry evidence."""
+        return {edge.bnode_id for edge in sa.edges.values()
+                if len(edge.evidence_uris) == 0}
+
+    def check_invalid_gp_mf_relation(self, gcg, sa):
+        """#2: GP<->MF backbone relation validity. Annotation-wide exemption:
+        at least one valid backbone edge exempts the rest."""
+        enabled_by = self.rel_enabled_by
+        contributes_to = self.rel_contributes_to
+        mf_source_extensions = {self.rel_has_input, self.rel_has_output}
+        invalid_candidates = []
+        has_valid_backbone = False
+        for edge in sa.edges.values():
+            src_mf = self._resolve_mf_type(edge.source_type, gcg.g)
+            tgt_mf = self._resolve_mf_type(edge.target_type, gcg.g)
+            # Skip non-MF and MF<->MF edges (latter is mf_causal_mf's domain)
+            if (src_mf is None) == (tgt_mf is None):
+                continue
+            if src_mf is not None:
+                other_type = edge.target_type
+                mf_on = "source"
+            else:
+                other_type = edge.source_type
+                mf_on = "target"
+            # Only MF<->gene-product edges are GP-MF backbone candidates.
+            if self._gene_product_namespace_key(other_type) not in self.GP_NAMESPACE_KEYS:
+                continue
+            if mf_on == "source":
+                if edge.property_uri == enabled_by:
+                    has_valid_backbone = True
+                elif edge.property_uri in mf_source_extensions:
+                    continue  # allowed MF->GP extension (has_input/has_output)
+                else:
+                    invalid_candidates.append(edge.bnode_id)
+            else:  # mf_on == "target"
+                if edge.property_uri == contributes_to:
+                    has_valid_backbone = True
+                else:
+                    invalid_candidates.append(edge.bnode_id)
+        if not has_valid_backbone and invalid_candidates:
+            return set(invalid_candidates)
+        return set()
+
+    def check_multiple_mf_anatomy(self, gcg, sa):
+        """#12: at most one MF->anatomical-structure edge."""
+        mf_anatomy_edges = [
+            edge for edge in sa.edges.values()
+            if self._go_aspect(edge.source_type, gcg.g) == "MF"
+            and self._is_anatomical_structure(edge.target_type)
+        ]
+        if len(mf_anatomy_edges) > 1:
+            return {e.bnode_id for e in mf_anatomy_edges}
+        return set()
+
+    def check_enabler_not_gp(self, gcg, sa):
+        """#13: the enabler (target of enabled_by) must be a gene product."""
+        flagged = set()
+        for edge in sa.edges.values():
+            if edge.property_uri == self.rel_enabled_by:
+                if self._gene_product_namespace_key(edge.target_type) not in self.GP_NAMESPACE_KEYS:
+                    flagged.add(edge.bnode_id)
+        return flagged
+
+    def _relation_rule_failures(self, gcg, sa, rule_key):
+        """Backbone-gated relation-validity failures for one rule key (#3/#4/
+        #5/#6/#10). Returns empty when the rule is absent (RO-dependent rules
+        without RO). Endpoint categories are disjoint, so evaluating a single
+        rule reproduces the original first-match-wins loop for that key."""
+        rule = next((r for r in self.relation_rules if r["key"] == rule_key), None)
+        if rule is None:
+            return set()
+        flagged = set()
+        for edge in sa.edges.values():
+            prop = str(edge.property_uri)
+            if prop not in self.backbone_relations:
+                continue  # extension-relation edge -> not validated
+            if self._matches_relation_rule(edge, rule, gcg.g):
+                if prop not in rule["valid"]:
+                    flagged.add(edge.bnode_id)
+        return flagged
+
+    def check_invalid_bp_cc_relation(self, gcg, sa):
+        """#10: BP->CC/anatomy must be occurs_in."""
+        return self._relation_rule_failures(gcg, sa, "invalid_bp_cc_relation")
+
+    def check_invalid_gp_cc_relation(self, gcg, sa):
+        """#3: GP->non-root CC must be located_in."""
+        return self._relation_rule_failures(gcg, sa, "invalid_gp_cc_relation")
+
+    def check_invalid_mf_cc_relation(self, gcg, sa):
+        """#6: root-MF->non-root CC must be is_active_in."""
+        return self._relation_rule_failures(gcg, sa, "invalid_mf_cc_relation")
+
+    def check_invalid_gp_bp_relation(self, gcg, sa):
+        """#4 (RO): GP->BP must be in the acts_upstream_of_or_within family."""
+        return self._relation_rule_failures(gcg, sa, "invalid_gp_bp_relation")
+
+    def check_invalid_mf_bp_relation(self, gcg, sa):
+        """#5 (RO): root-MF->non-root BP must be part_of/acts_upstream/causal."""
+        return self._relation_rule_failures(gcg, sa, "invalid_mf_bp_relation")
+
+    # Ordered list of all per-annotation check keys. RO-dependent checks
+    # (mf_causal_mf, invalid_gp_bp_relation, invalid_mf_bp_relation) naturally
+    # return empty when no RO is loaded.
+    UNIT_CHECK_KEYS = [
+        "inconsistent_evidence",
+        "multiple_mf_bp",
+        "mf_causal_mf",
+        "edge_without_evidence",
+        "invalid_gp_mf_relation",
+        "multiple_mf_anatomy",
+        "enabler_not_gp",
+        "invalid_bp_cc_relation",
+        "invalid_gp_cc_relation",
+        "invalid_mf_cc_relation",
+        "invalid_gp_bp_relation",
+        "invalid_mf_bp_relation",
+    ]
+
+    def run_check(self, key, gcg, sa):
+        """Run a single check by key, returning its flagged edge-bnode set."""
+        return getattr(self, "check_" + key)(gcg, sa)
+
+    def run_all_checks(self, gcg, sa):
+        """Run every check; return {key -> flagged set} (including empties)."""
+        return {key: self.run_check(key, gcg, sa) for key in self.UNIT_CHECK_KEYS}
 
     def filter_out_non_std_annotations(self, go_cam_graph: GoCamGraph):
         new_standard_annotations = []
         non_standard_annotations = []
-
         for std_annot in go_cam_graph.standard_annotations:
-            failed_checks = {}
-
-            # Check 1: Evidence consistency - all edges must have matching evidence metadata
-            if not go_cam_graph.has_consistent_evidence_across_edges(std_annot):
-                failed_checks["inconsistent_evidence"] = set()
-                # Every edge gets this failure
-                for edge_bnode_id in std_annot.edges.keys():
-                    failed_checks["inconsistent_evidence"].add(edge_bnode_id)
-
-            # Check #11: Cardinality MF->BP should be 1 (refines the former
-            # multiple_mf_part_of: narrows to MF->BP and admits the same relation
-            # set as #5 -- self.mf_bp_valid_relations, built once in __init__).
-            mf_bp_edges = [
-                edge for edge in std_annot.edges.values()
-                if self._go_aspect(edge.source_type, go_cam_graph.g) == "MF"
-                and self._go_aspect(edge.target_type, go_cam_graph.g) == "BP"
-                and str(edge.property_uri) in self.mf_bp_valid_relations
-            ]
-            if len(mf_bp_edges) > 1:
-                failed_checks["multiple_mf_bp"] = {e.bnode_id for e in mf_bp_edges}
-
-            # Check 3: Causal relation edge between two molecular function nodes
-            # If RO ontology was provided and causal relations were loaded
-            if self.causal_relations:
-                for edge in std_annot.edges.values():
-                    if (self.uri_is_causal_relation(edge.property_uri) and
-                            self.uri_is_molecular_function(edge.source_type) and
-                            self.uri_is_molecular_function(edge.target_type)):
-                        # Uh oh, start reporting the failure
-                        if "mf_causal_mf" not in failed_checks:
-                            failed_checks["mf_causal_mf"] = set()
-                        failed_checks["mf_causal_mf"].add(edge.bnode_id)
-
-            # Check 4: Edges without evidence
-            for edge in std_annot.edges.values():
-                if len(edge.evidence_uris) == 0:
-                    if "edge_without_evidence" not in failed_checks:
-                        failed_checks["edge_without_evidence"] = set()
-                    failed_checks["edge_without_evidence"].add(edge.bnode_id)
-
-            # Check 5: GP<->MF backbone must use `enabled_by` (MF as source) or
-            # `contributes to` / RO:0002326 (MF as target). NOT-qualified MFs are
-            # recognized via owl:complementOf class expressions. The non-MF
-            # endpoint must be a gene product (GP_NAMESPACE_KEYS) -- anatomy/
-            # ontology targets (EMAPA, WBbt, CL, ...) are extensions, not GPs.
-            # `has_input`/`has_output` are allowed MF->GP extension relations.
-            # Annotations with at least one valid backbone edge pass; those with
-            # no valid backbone get every invalid candidate edge flagged.
-            enabled_by = self.rel_enabled_by
-            contributes_to = self.rel_contributes_to
-            mf_source_extensions = {self.rel_has_input, self.rel_has_output}
-            invalid_candidates = []
-            has_valid_backbone = False
-            for edge in std_annot.edges.values():
-                src_mf = self._resolve_mf_type(edge.source_type, go_cam_graph.g)
-                tgt_mf = self._resolve_mf_type(edge.target_type, go_cam_graph.g)
-                # Skip non-MF and MF<->MF edges (latter is mf_causal_mf's domain)
-                if (src_mf is None) == (tgt_mf is None):
-                    continue
-                if src_mf is not None:
-                    other_type = edge.target_type
-                    mf_on = "source"
-                else:
-                    other_type = edge.source_type
-                    mf_on = "target"
-                # Only MF<->gene-product edges are GP-MF backbone candidates.
-                # Anatomy/ontology targets resolve to keys absent from the set.
-                if self._gene_product_namespace_key(other_type) not in self.GP_NAMESPACE_KEYS:
-                    continue
-                if mf_on == "source":
-                    if edge.property_uri == enabled_by:
-                        has_valid_backbone = True
-                    elif edge.property_uri in mf_source_extensions:
-                        continue  # allowed MF->GP extension (has_input/has_output)
-                    else:
-                        invalid_candidates.append(edge.bnode_id)
-                else:  # mf_on == "target"
-                    if edge.property_uri == contributes_to:
-                        has_valid_backbone = True
-                    else:
-                        invalid_candidates.append(edge.bnode_id)
-            if not has_valid_backbone and invalid_candidates:
-                failed_checks.setdefault("invalid_gp_mf_relation", set()).update(invalid_candidates)
-
-            # Check #12: Cardinality MF->anatomical-structure should be 1.
-            mf_anatomy_edges = [
-                edge for edge in std_annot.edges.values()
-                if self._go_aspect(edge.source_type, go_cam_graph.g) == "MF"
-                and self._is_anatomical_structure(edge.target_type)
-            ]
-            if len(mf_anatomy_edges) > 1:
-                failed_checks["multiple_mf_anatomy"] = {e.bnode_id for e in mf_anatomy_edges}
-
-            # Check #13: Enabler must be a gene product (not GO, ChEBI, etc.).
-            # Complements #2, which skips non-GP endpoints. The enabler is the
-            # target of an enabled_by (MF->GP) edge.
-            for edge in std_annot.edges.values():
-                if edge.property_uri == self.rel_enabled_by:
-                    if self._gene_product_namespace_key(edge.target_type) not in self.GP_NAMESPACE_KEYS:
-                        failed_checks.setdefault("enabler_not_gp", set()).add(edge.bnode_id)
-
-            # Checks 3, 4, 5, 6, 10: relation-validity rule table. These validate
-            # the BACKBONE of an annotation only. An edge is subject to validation
-            # only if its relation is a recognized backbone/placement relation
-            # (self.backbone_relations); edges using any other relation are
-            # annotation extensions (e.g. BP -results_in_development_of-> anatomy)
-            # and are informational, not failures (consistent with #7/#8/#9).
-            # Endpoint categories are disjoint, so at most one rule matches an edge.
-            for edge in std_annot.edges.values():
-                prop = str(edge.property_uri)
-                if prop not in self.backbone_relations:
-                    continue  # extension-relation edge -> not validated
-                for rule in self.relation_rules:
-                    if self._matches_relation_rule(edge, rule, go_cam_graph.g):
-                        if prop not in rule["valid"]:
-                            failed_checks.setdefault(rule["key"], set()).add(edge.bnode_id)
-                        break
-
+            failed_checks = {k: v for k, v
+                             in self.run_all_checks(go_cam_graph, std_annot).items() if v}
             std_annot.failed_checks = failed_checks
-
-            # Categorize annotation
             if failed_checks:
                 non_standard_annotations.append(std_annot)
             else:
                 new_standard_annotations.append(std_annot)
-
         go_cam_graph.standard_annotations = new_standard_annotations
         go_cam_graph.non_standard_annotations = non_standard_annotations
         return go_cam_graph

--- a/src/gocam_unwinder/ratchet/__init__.py
+++ b/src/gocam_unwinder/ratchet/__init__.py
@@ -1,0 +1,31 @@
+"""Standard-annotation ratchet: a two-level, monotonic filtering mini-pipeline.
+
+The ratchet carries a shrinking *set* of items through an ordered series of rule
+stages. Each stage reads the prior stage's survivors, applies one rule, and
+writes the new survivors plus a "what got filtered out" report. Phase A ratchets
+whole models; Phase B ratchets annotation units over the surviving models.
+
+Rules are data (``rules/NN-name/rule.yaml`` [+ ``query.rq``]); the engine runs
+them per-file in-process with rdflib, supporting both Python predicates (reusing
+the existing ``gocam_ttl`` checks) and standalone SPARQL ASK/SELECT rules.
+
+See ``docs/plans/2026-06-25-standard-annotation-ratchet.md``.
+"""
+
+from .core import Item, Manifest, StageResult, Verdict
+from .rules import Rule, load_rules
+from .runner import run_stage
+from .engine import PythonRuleAdapter, SparqlRuleAdapter, resolve_adapter
+
+__all__ = [
+    "Item",
+    "Manifest",
+    "StageResult",
+    "Verdict",
+    "Rule",
+    "load_rules",
+    "run_stage",
+    "PythonRuleAdapter",
+    "SparqlRuleAdapter",
+    "resolve_adapter",
+]

--- a/src/gocam_unwinder/ratchet/__main__.py
+++ b/src/gocam_unwinder/ratchet/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/src/gocam_unwinder/ratchet/cli.py
+++ b/src/gocam_unwinder/ratchet/cli.py
@@ -1,0 +1,373 @@
+"""Run the two-level standard-annotation ratchet end to end.
+
+Phase A (model): a disk-materialized model ratchet. Each model rule reads the
+prior stage's survivor manifest (a set of .ttl paths), removes models, and
+writes survivors + rejects + a per-stage report under ``<out>/phase-a/``.
+
+Phase B (unit): for each surviving model, parse once (classify=False) and run
+the ordered unit rules over its annotation units IN MEMORY; a unit is removed by
+the first rule that flags it (monotonic). Per-stage reject reports are aggregated
+across all models under ``<out>/phase-b/``. This avoids re-parsing / serializing
+rdflib graphs between unit stages while preserving the per-stage shrink.
+
+A unit survives all unit rules iff no check flags it iff it is a standard
+annotation -- so the final surviving unit set equals the union of every surviving
+model's standard annotations.
+"""
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+from .core import Item, Manifest
+from .engine import resolve_adapter
+from .model_rules import build_model_rule_registry, load_true_gocam_ids
+from .rules import load_rules
+from .runner import _write_jsonl, _write_rejects_tsv, run_stage
+from .summary import write_summary
+from .unit_rules import build_unit_rule_registry, parse_model_units
+
+
+@dataclass
+class StageStat:
+    phase: str
+    index: int
+    rule_id: str
+    in_count: int
+    out_count: int
+
+    @property
+    def removed(self) -> int:
+        return self.in_count - self.out_count
+
+
+@dataclass
+class RatchetResult:
+    stages: List[StageStat]
+    phase_a_survivors: List[str]
+    final_units: List[str]
+    out_dir: Path
+
+
+def _run_phase_b(builder, models_manifest, unit_rules, unit_registry, out_dir,
+                 base_index=0):
+    """Stream each surviving model's units through the ordered unit rules,
+    aggregating per-stage reports. Returns (stage_stats, final_unit_ids)."""
+    reports_dir = out_dir / "reports"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    adapters = [(j, rule, resolve_adapter(rule, unit_registry))
+                for j, rule in enumerate(unit_rules)]
+    n = len(adapters)
+    rows = [[] for _ in range(n)]
+    rejects = [[] for _ in range(n)]
+    in_count = [0] * n
+    out_count = [0] * n
+    final_units = []
+    model_records = []
+
+    for item in models_manifest.items:
+        gcg, units = parse_model_units(builder, item.path)
+        total_units = len(units)
+        current = units
+        for j, rule, adapter in adapters:
+            in_count[j] += len(current)
+            survivors = []
+            for unit in current:
+                verdict = adapter.apply(unit, builder)
+                row = {
+                    "id": unit.id,
+                    "decision": ("skip" if verdict.skipped
+                                 else "keep" if verdict.keep else "remove"),
+                    "rule": rule.id,
+                    "model": unit.meta.get("model_id"),
+                }
+                if verdict.reason:
+                    row["reason"] = verdict.reason
+                row.update(verdict.detail)
+                rows[j].append(row)
+                if verdict.keep:
+                    survivors.append(unit)
+                else:
+                    rejects[j].append((unit, verdict))
+            out_count[j] += len(survivors)
+            current = survivors
+        final_units.extend(unit.id for unit in current)
+        # Per-model stats for the dashboard's explorable axes (modelstate,
+        # editorial group, pass rate). groups are raw providedBy URIs unless the
+        # builder has a groups lookup; the dashboard resolves them to labels.
+        model_records.append({
+            "model": item.id,
+            "modelstate": gcg.modelstate,
+            "groups": gcg.groups or [],
+            "title": gcg.title,
+            "total_units": total_units,
+            "passing_units": len(current),
+        })
+
+    stage_stats = []
+    for j, rule, _ in adapters:
+        idx = base_index + j
+        prefix = f"{idx:02d}-{rule.id}"
+        _write_jsonl(reports_dir / f"{prefix}.jsonl", rows[j])
+        _write_rejects_tsv(out_dir / f"{prefix}.rejects.tsv", rejects[j], rule.id)
+        stage_stats.append(StageStat("B", idx, rule.id, in_count[j], out_count[j]))
+    return stage_stats, final_units, model_records
+
+
+def run_ratchet(models_dir, rules_dir="rules", out_dir=None, *, go=None, ro=None,
+                groups=None, skip_prefixes=None, true_gocam_ids=None,
+                true_gocam_source=None, limit=None, builder=None,
+                model_paths=None) -> RatchetResult:
+    """Run the full two-level ratchet over ``models_dir`` (or an explicit
+    ``model_paths`` list, used by the sharded runner).
+
+    builder -- optional prebuilt GoCamGraphBuilder (avoids re-parsing the GO
+               ontology in tests). If absent and ``go`` is given, one is built.
+    """
+    out_dir = Path(out_dir)
+    phase_a_dir = out_dir / "phase-a"
+    phase_b_dir = out_dir / "phase-b"
+    phase_a_dir.mkdir(parents=True, exist_ok=True)
+
+    if true_gocam_ids is None and true_gocam_source is not None:
+        true_gocam_ids = load_true_gocam_ids(true_gocam_source)
+    true_gocam_ids = true_gocam_ids or set()
+
+    if model_paths is not None:
+        ttls = [Path(p) for p in model_paths]
+    else:
+        ttls = sorted(p for p in Path(models_dir).iterdir() if p.suffix == ".ttl")
+    if limit:
+        ttls = ttls[:limit]
+    manifest = Manifest([Item(id=p.stem, path=p) for p in ttls])
+
+    stages: List[StageStat] = []
+
+    # --- Phase A: model ratchet ---
+    model_rules = load_rules(rules_dir, phase="model")
+    model_registry = build_model_rule_registry(skip_prefixes=skip_prefixes,
+                                               true_gocam_ids=true_gocam_ids)
+    for i, rule in enumerate(model_rules):
+        adapter = resolve_adapter(rule, model_registry)
+        result = run_stage(adapter, manifest, out_dir=phase_a_dir, index=i,
+                           stage_id=rule.id, ctx=None)
+        stages.append(StageStat("A", i, rule.id, result.in_count, result.out_count))
+        manifest = result.survivors
+    phase_a_survivors = list(manifest.ids)
+    manifest.write(out_dir / "SA-final.models.manifest.jsonl")
+
+    # --- Phase B: unit ratchet over surviving models ---
+    final_units: List[str] = []
+    if builder is None and go is not None:
+        from ..gocam_ttl import GoCamGraphBuilder
+        builder = GoCamGraphBuilder(go, ro, groups)
+
+    if builder is not None:
+        phase_b_dir.mkdir(parents=True, exist_ok=True)
+        unit_rules = load_rules(rules_dir, phase="unit")
+        unit_registry = build_unit_rule_registry()
+        b_stats, final_units, model_records = _run_phase_b(
+            builder, manifest, unit_rules, unit_registry, phase_b_dir,
+            base_index=len(model_rules))
+        stages.extend(b_stats)
+        Manifest([Item(id=uid) for uid in final_units]).write(
+            out_dir / "SB-final.units.manifest.jsonl")
+        with open(out_dir / "model_stats.jsonl", "w") as fh:
+            for rec in model_records:
+                fh.write(json.dumps(rec) + "\n")
+
+    write_summary(stages, out_dir / "summary.tsv")
+    return RatchetResult(stages, phase_a_survivors, final_units, out_dir)
+
+
+# ----------------------------------------------------------------------
+# Sharding (Task 8): split the corpus into N independent shards, run each as
+# its own ratchet concurrently, then merge. A model is never split across
+# shards, so the merged result is IDENTICAL to a single-process run (the only
+# cross-item dependencies -- the annotation partition and the partition-
+# dependent unit checks -- stay inside one model). Shards resume via a .done
+# marker; each worker process loads its own GO ontology copy.
+# ----------------------------------------------------------------------
+
+@dataclass
+class ShardedResult:
+    stages: List[StageStat]
+    out_dir: Path
+    n_shards: int
+
+
+def _partition(items, n):
+    """Round-robin partition (spreads file-size skew across shards)."""
+    return [items[k::n] for k in range(n)]
+
+
+def _save_stage_stats(shard_dir, stages):
+    import json
+    data = [{"phase": s.phase, "index": s.index, "rule_id": s.rule_id,
+             "in_count": s.in_count, "out_count": s.out_count} for s in stages]
+    (shard_dir / "stages.json").write_text(json.dumps(data))
+
+
+def _load_stage_stats(shard_dir):
+    import json
+    data = json.loads((shard_dir / "stages.json").read_text())
+    return [StageStat(d["phase"], d["index"], d["rule_id"],
+                      d["in_count"], d["out_count"]) for d in data]
+
+
+def _run_shard(task):
+    """Worker entry point (top-level so it is picklable for multiprocessing).
+    Runs the ratchet over one shard's models, with shard-level resume."""
+    (k, model_path_strs, rules_dir, out_root, go, ro, groups,
+     skip_prefixes, true_gocam_ids) = task
+    shard_dir = Path(out_root) / "shards" / f"shard-{k:03d}"
+    if (shard_dir / ".done").exists():
+        return _load_stage_stats(shard_dir)  # resume: already complete
+    shard_dir.mkdir(parents=True, exist_ok=True)
+    result = run_ratchet(
+        None, rules_dir=rules_dir, out_dir=shard_dir, go=go, ro=ro, groups=groups,
+        skip_prefixes=skip_prefixes, true_gocam_ids=set(true_gocam_ids),
+        model_paths=model_path_strs)
+    _save_stage_stats(shard_dir, result.stages)
+    (shard_dir / ".done").write_text("ok\n")
+    return result.stages
+
+
+def _aggregate_stage_stats(shard_stage_lists):
+    """Sum per-stage in/out counts across shards (shards share the rule set)."""
+    agg = {}
+    order = []
+    for stages in shard_stage_lists:
+        for s in stages:
+            key = (s.phase, s.index, s.rule_id)
+            if key not in agg:
+                agg[key] = StageStat(s.phase, s.index, s.rule_id, 0, 0)
+                order.append(key)
+            agg[key].in_count += s.in_count
+            agg[key].out_count += s.out_count
+    return [agg[k] for k in sorted(order, key=lambda key: (key[0], key[1]))]
+
+
+def _merge_named(shard_dirs, rel_glob, dest_dir, skip_header):
+    """Concatenate same-named files across shards into ``dest_dir``.
+
+    skip_header -- keep only the first file's header line (TSV reject reports);
+                   otherwise concatenate verbatim (JSONL reports).
+    """
+    from collections import defaultdict
+    groups = defaultdict(list)
+    for sd in shard_dirs:
+        for f in sorted(sd.glob(rel_glob)):
+            groups[f.name].append(f)
+    if groups:
+        dest_dir.mkdir(parents=True, exist_ok=True)
+    for name, files in sorted(groups.items()):
+        with open(dest_dir / name, "w") as out:
+            for i, f in enumerate(files):
+                lines = f.read_text().splitlines()
+                if skip_header and i > 0 and lines:
+                    lines = lines[1:]
+                for line in lines:
+                    out.write(line + "\n")
+
+
+def _concat_shard_outputs(out_dir, shard_dirs):
+    for name in ("SA-final.models.manifest.jsonl", "SB-final.units.manifest.jsonl",
+                 "model_stats.jsonl"):
+        with open(out_dir / name, "w") as out:
+            for sd in shard_dirs:
+                f = sd / name
+                if f.exists():
+                    out.write(f.read_text())
+    # Merged reject reports (the "what got filtered out" deliverable) ...
+    _merge_named(shard_dirs, "phase-a/*.rejects.tsv", out_dir / "rejects", True)
+    _merge_named(shard_dirs, "phase-b/*.rejects.tsv", out_dir / "rejects", True)
+    # ... and the per-stage JSONL reports.
+    _merge_named(shard_dirs, "phase-a/reports/*.jsonl", out_dir / "reports", False)
+    _merge_named(shard_dirs, "phase-b/reports/*.jsonl", out_dir / "reports", False)
+
+
+def run_ratchet_sharded(models_dir, rules_dir="rules", out_dir=None, *, jobs=4,
+                        go=None, ro=None, groups=None, skip_prefixes=None,
+                        true_gocam_ids=None, true_gocam_source=None,
+                        limit=None) -> ShardedResult:
+    """Run the ratchet across ``jobs`` parallel shards, then merge.
+
+    Identical result to a single-process run (a model never spans shards).
+    Resumable: a killed run re-does only shards without a .done marker.
+    """
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    if true_gocam_ids is None and true_gocam_source is not None:
+        true_gocam_ids = load_true_gocam_ids(true_gocam_source)
+    true_gocam_ids = sorted(true_gocam_ids or set())  # picklable + stable
+
+    ttls = sorted(p for p in Path(models_dir).iterdir() if p.suffix == ".ttl")
+    if limit:
+        ttls = ttls[:limit]
+
+    shards = _partition([str(p) for p in ttls], jobs)
+    tasks = [
+        (k, shards[k], rules_dir, str(out_dir), go, ro, groups,
+         list(skip_prefixes or []), list(true_gocam_ids))
+        for k in range(jobs) if shards[k]
+    ]
+
+    if len(tasks) <= 1:
+        shard_stage_lists = [_run_shard(t) for t in tasks]
+    else:
+        from concurrent.futures import ProcessPoolExecutor
+        with ProcessPoolExecutor(max_workers=len(tasks)) as ex:
+            shard_stage_lists = list(ex.map(_run_shard, tasks))
+
+    merged_stages = _aggregate_stage_stats(shard_stage_lists)
+    shard_dirs = [out_dir / "shards" / f"shard-{t[0]:03d}" for t in tasks]
+    _concat_shard_outputs(out_dir, shard_dirs)
+    write_summary(merged_stages, out_dir / "summary.tsv")
+    return ShardedResult(merged_stages, out_dir, n_shards=len(tasks))
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        prog="python -m gocam_unwinder.ratchet",
+        description="Two-level standard-annotation ratchet over a GO-CAM corpus.")
+    ap.add_argument("--models-dir", required=True,
+                    help="Directory of GO-CAM .ttl models (S0).")
+    ap.add_argument("--rules-dir", default="rules",
+                    help="Directory of rule manifests (default: rules).")
+    ap.add_argument("--out-dir", required=True, help="Output directory.")
+    ap.add_argument("--go", help="GO ontology JSON (required for Phase B).")
+    ap.add_argument("--ro", help="RO ontology OWL (enables RO-dependent checks).")
+    ap.add_argument("--groups", help="groups.yaml for group label resolution.")
+    ap.add_argument("--skip-prefix", action="append", dest="skip_prefixes",
+                    default=[], metavar="PREFIX",
+                    help="Filename prefix to skip in Phase A (repeatable).")
+    ap.add_argument("--true-gocam-source", metavar="DIR_OR_FILE",
+                    help="Dir of true-GO-CAM JSONs (stems) or an id file (R1).")
+    ap.add_argument("--limit", type=int, default=None,
+                    help="Process only the first N models.")
+    ap.add_argument("--jobs", "-j", type=int, default=1,
+                    help="Parallel shards/workers (default 1). Each worker loads "
+                         "its own GO ontology copy, so bound by RAM. Resumable.")
+    args = ap.parse_args(argv)
+
+    if args.jobs and args.jobs > 1:
+        result = run_ratchet_sharded(
+            args.models_dir, args.rules_dir, args.out_dir, jobs=args.jobs,
+            go=args.go, ro=args.ro, groups=args.groups,
+            skip_prefixes=args.skip_prefixes,
+            true_gocam_source=args.true_gocam_source, limit=args.limit)
+    else:
+        result = run_ratchet(
+            args.models_dir, args.rules_dir, args.out_dir, go=args.go, ro=args.ro,
+            groups=args.groups, skip_prefixes=args.skip_prefixes,
+            true_gocam_source=args.true_gocam_source, limit=args.limit)
+    print((Path(args.out_dir) / "summary.tsv").read_text())
+    return result
+
+
+if __name__ == "__main__":
+    main()

--- a/src/gocam_unwinder/ratchet/core.py
+++ b/src/gocam_unwinder/ratchet/core.py
@@ -1,0 +1,138 @@
+"""Core data types for the standard-annotation ratchet.
+
+These are deliberately generic over what an "item" is: a whole model in Phase A,
+an annotation unit in Phase B. The rule adapters know how to interpret an item;
+the runner only needs each item's stable ``id`` and the ability to hand the item
+to a rule. Survivor sets are serialized as JSONL manifests so runs are
+resumable and each stage reads the prior stage's output from disk.
+"""
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, List, Optional, Tuple
+
+
+@dataclass
+class Item:
+    """One element of the set flowing through the ratchet.
+
+    id    -- stable, unique identifier within the set (e.g. a model id, or
+             ``"<model_id>#<unit_index>"`` for an annotation unit).
+    path  -- backing file for the item, if any (the model ``.ttl`` in Phase A).
+    meta  -- arbitrary metadata carried forward between stages; persisted in the
+             survivor manifest so later stages and reports can use it.
+    """
+
+    id: str
+    path: Optional[Path] = None
+    meta: dict = field(default_factory=dict)
+    # Runtime-only payload (e.g. a parsed GoCamGraph + annotation for a Phase B
+    # unit). Deliberately NOT serialized into the manifest and excluded from
+    # equality, so it can hold non-JSON-able in-memory objects.
+    payload: dict = field(default_factory=dict, compare=False, repr=False)
+
+    def to_record(self) -> dict:
+        rec = {"id": self.id}
+        if self.path is not None:
+            rec["path"] = str(self.path)
+        if self.meta:
+            rec["meta"] = self.meta
+        return rec
+
+    @classmethod
+    def from_record(cls, rec: dict) -> "Item":
+        path = rec.get("path")
+        return cls(id=rec["id"], path=Path(path) if path else None,
+                   meta=rec.get("meta", {}))
+
+
+@dataclass
+class Verdict:
+    """The outcome of applying one rule to one item.
+
+    keep    -- True if the item survives this stage (passes the rule).
+    reason  -- short machine key explaining a removal (or a skip); typically the
+               rule id. ``None`` for a plain pass.
+    detail  -- extra fields for the report row (e.g. the source/predicate/target
+               of the offending edge).
+    skipped -- True if the rule did not actually run (e.g. an RO-dependent rule
+               with no RO loaded). A skipped rule KEEPS the item but is recorded
+               as ``skip`` so a stage that silently did nothing stays visible.
+    """
+
+    keep: bool
+    reason: Optional[str] = None
+    detail: dict = field(default_factory=dict)
+    skipped: bool = False
+
+    @classmethod
+    def survive(cls, **detail) -> "Verdict":
+        return cls(keep=True, detail=detail)
+
+    @classmethod
+    def reject(cls, reason, **detail) -> "Verdict":
+        return cls(keep=False, reason=reason, detail=detail)
+
+    @classmethod
+    def skip(cls, reason) -> "Verdict":
+        return cls(keep=True, reason=reason, skipped=True)
+
+
+@dataclass
+class Manifest:
+    """An ordered set of items = the set ``Sn`` at some point in the ratchet."""
+
+    items: List[Item]
+
+    @property
+    def ids(self) -> List[str]:
+        return [it.id for it in self.items]
+
+    def __len__(self) -> int:
+        return len(self.items)
+
+    def __iter__(self):
+        return iter(self.items)
+
+    @classmethod
+    def of(cls, ids) -> "Manifest":
+        """Convenience for tests / bootstrapping: a manifest from bare ids."""
+        return cls([Item(id=i) for i in ids])
+
+    def write(self, path) -> None:
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w") as fh:
+            for it in self.items:
+                fh.write(json.dumps(it.to_record()) + "\n")
+
+    @classmethod
+    def read(cls, path) -> "Manifest":
+        items = []
+        with open(path) as fh:
+            for line in fh:
+                line = line.strip()
+                if line:
+                    items.append(Item.from_record(json.loads(line)))
+        return cls(items)
+
+
+@dataclass
+class StageResult:
+    """What one stage produced, returned to the orchestrator."""
+
+    index: int
+    stage_id: str
+    survivors: Manifest
+    rejected: List[Tuple[Item, Verdict]]
+    report_rows: List[dict]
+    in_count: int
+
+    @property
+    def out_count(self) -> int:
+        return len(self.survivors)
+
+    @property
+    def rejected_ids(self) -> List[str]:
+        return [it.id for it, _ in self.rejected]

--- a/src/gocam_unwinder/ratchet/dashboard.py
+++ b/src/gocam_unwinder/ratchet/dashboard.py
@@ -1,0 +1,546 @@
+"""Build a self-contained, shareable HTML dashboard from a ratchet run.
+
+Reads a run's ``summary.tsv`` + ``rejects/*.rejects.tsv`` + ``model_stats.jsonl``
+(and the ``rules/`` manifests for descriptions) and emits a single
+``dashboard.html`` with the data embedded inline -- no external libraries, no
+server, no network: it works by double-clicking the file, so it's easy to share.
+
+Beyond the per-stage funnel and per-rule drill-down, it provides explorable model
+axes: modelstate, editorial group (providedBy, resolved via groups.yaml), models
+passing, per-model percent passing, with deep links into the Noctua graph editor.
+
+    python -m gocam_unwinder.ratchet.dashboard \\
+        --out-dir target_ratchet_YYYYMMDD/out --rules-dir rules \\
+        --groups-yaml target/groups.yaml \\
+        --output target_ratchet_YYYYMMDD/dashboard.html
+"""
+
+import argparse
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+
+import yaml
+
+DEFAULT_NOCTUA_BASE = "https://noctua.geneontology.org/editor/graph/"
+
+
+def _read_summary(out_dir):
+    rows = []
+    with open(out_dir / "summary.tsv") as fh:
+        next(fh)  # header
+        for line in fh:
+            parts = line.rstrip("\n").split("\t")
+            if len(parts) < 6:
+                continue
+            phase, index, rule_id, n_in, removed, n_out = parts[:6]
+            rows.append({
+                "phase": phase, "index": index, "rule_id": rule_id,
+                "in": int(n_in), "removed": int(removed), "out": int(n_out),
+            })
+    return rows
+
+
+def _load_rule_meta(rules_dir):
+    meta = {}
+    for manifest in Path(rules_dir).glob("*/rule.yaml"):
+        data = yaml.safe_load(manifest.read_text()) or {}
+        if "id" in data:
+            meta[data["id"]] = {
+                "tsv": data.get("tsv"),
+                "kind": data.get("kind"),
+                "description": " ".join((data.get("description") or "").split()),
+            }
+    return meta
+
+
+def _load_groups(groups_yaml):
+    """groups.yaml (go-site metadata) -> {group URI: label}."""
+    if not groups_yaml or not Path(groups_yaml).exists():
+        return {}
+    data = yaml.safe_load(Path(groups_yaml).read_text()) or []
+    lookup = {}
+    for g in data:
+        if isinstance(g, dict) and g.get("id") and g.get("label"):
+            lookup[g["id"]] = g["label"]
+    return lookup
+
+
+def _short_group(uri):
+    """Fallback label for an unmapped group URI: its host/path, scheme stripped."""
+    s = str(uri).split("://", 1)[-1].rstrip("/")
+    return s or str(uri)
+
+
+def _model_of(item_id):
+    """Reduce a reject id to its model id (Phase B id is '<modelURI>#<n>')."""
+    base = item_id.split("#", 1)[0]
+    return base.rsplit("/", 1)[-1]
+
+
+def _pattern_label(detail):
+    if "predicate" in detail:
+        return f'{detail.get("predicate", "?")}  →  {detail.get("target", "?")}'
+    if "prefix" in detail:
+        return f'prefix: {detail["prefix"]}'
+    if "modelstate" in detail:
+        return f'modelstate: {detail["modelstate"]}'
+    return "(removed)"
+
+
+def _aggregate_rejects(reject_file, top=30, examples_per=5):
+    counts = Counter()
+    examples = defaultdict(list)
+    sources = defaultdict(Counter)
+    total = 0
+    if not reject_file.exists():
+        return {"total": 0, "patterns": []}
+    with open(reject_file) as fh:
+        next(fh, None)  # header
+        for line in fh:
+            parts = line.rstrip("\n").split("\t")
+            if len(parts) < 4:
+                continue
+            item_id, detail_raw = parts[0], parts[3]
+            try:
+                detail = json.loads(detail_raw) if detail_raw else {}
+            except json.JSONDecodeError:
+                detail = {}
+            label = _pattern_label(detail)
+            counts[label] += 1
+            total += 1
+            if len(examples[label]) < examples_per:
+                examples[label].append(_model_of(item_id))
+            src = detail.get("source")
+            if src:
+                sources[label][src.rsplit("/", 1)[-1]] += 1
+    patterns = []
+    for label, count in counts.most_common(top):
+        top_src = [s for s, _ in sources[label].most_common(3)] if sources.get(label) else []
+        patterns.append({"label": label, "count": count,
+                         "examples": examples[label], "sources": top_src})
+    return {"total": total, "patterns": patterns}
+
+
+def _read_model_stats(out_dir, groups_lookup):
+    """Per-model records (one per Phase B model) with resolved group labels."""
+    path = Path(out_dir) / "model_stats.jsonl"
+    if not path.exists():
+        return None
+    models = []
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        r = json.loads(line)
+        groups = [groups_lookup.get(g, _short_group(g)) for g in (r.get("groups") or [])]
+        models.append({
+            "model": r["model"],
+            "modelstate": r.get("modelstate") or "unknown",
+            "groups": groups or ["(none)"],
+            "total": r.get("total_units", 0),
+            "passing": r.get("passing_units", 0),
+        })
+    return models
+
+
+def _build_models_block(models, noctua_base):
+    """Compact, embeddable model table + axis-ready encoding."""
+    states = sorted({m["modelstate"] for m in models})
+    state_idx = {s: i for i, s in enumerate(states)}
+    group_set = sorted({g for m in models for g in m["groups"]})
+    group_idx = {g: i for i, g in enumerate(group_set)}
+    rows = [[m["model"], state_idx[m["modelstate"]],
+             [group_idx[g] for g in m["groups"]], m["total"], m["passing"]]
+            for m in models]
+
+    hist = {"0%": 0, "1–25%": 0, "26–50%": 0, "51–75%": 0, "76–99%": 0, "100%": 0}
+    for m in models:
+        if m["total"] == 0:
+            continue
+        p = 100.0 * m["passing"] / m["total"]
+        if p == 0:
+            hist["0%"] += 1
+        elif p <= 25:
+            hist["1–25%"] += 1
+        elif p <= 50:
+            hist["26–50%"] += 1
+        elif p <= 75:
+            hist["51–75%"] += 1
+        elif p < 100:
+            hist["76–99%"] += 1
+        else:
+            hist["100%"] += 1
+
+    return {
+        "rows": rows, "modelstates": states, "groups": group_set,
+        "n": len(models),
+        "passing": sum(1 for m in models if m["passing"] > 0),
+        "total_units": sum(m["total"] for m in models),
+        "passing_units": sum(m["passing"] for m in models),
+        "histogram": hist, "noctua_base": noctua_base,
+    }
+
+
+def build_data(out_dir, rules_dir, groups_yaml=None, noctua_base=DEFAULT_NOCTUA_BASE):
+    out_dir = Path(out_dir)
+    summary = _read_summary(out_dir)
+    meta = _load_rule_meta(rules_dir)
+    rejects_dir = out_dir / "rejects"
+
+    stages = []
+    for row in summary:
+        rule_id = row["rule_id"]
+        agg = _aggregate_rejects(rejects_dir / f"{row['index']}-{rule_id}.rejects.tsv")
+        rmeta = meta.get(rule_id, {})
+        stages.append({
+            "phase": row["phase"], "index": row["index"], "rule_id": rule_id,
+            "tsv": rmeta.get("tsv"), "kind": rmeta.get("kind"),
+            "description": rmeta.get("description", ""),
+            "in": row["in"], "removed": row["removed"], "out": row["out"],
+            "patterns": agg["patterns"],
+        })
+
+    phase_a = [s for s in stages if s["phase"] == "A"]
+    phase_b = [s for s in stages if s["phase"] == "B"]
+    headline = {
+        "s0_models": phase_a[0]["in"] if phase_a else 0,
+        "candidate_models": phase_a[-1]["out"] if phase_a else 0,
+        "annotation_units": phase_b[0]["in"] if phase_b else 0,
+        "standard_annotations": phase_b[-1]["out"] if phase_b else 0,
+    }
+
+    models = _read_model_stats(out_dir, _load_groups(groups_yaml))
+    models_block = _build_models_block(models, noctua_base) if models else None
+
+    return {"label": out_dir.parent.name or out_dir.name,
+            "headline": headline, "stages": stages, "models": models_block,
+            "noctua_base": noctua_base}
+
+
+def build_dashboard(out_dir, rules_dir, output_html, groups_yaml=None,
+                    noctua_base=DEFAULT_NOCTUA_BASE):
+    data = build_data(out_dir, rules_dir, groups_yaml, noctua_base)
+    html = _TEMPLATE.replace("/*__DATA__*/", json.dumps(data))
+    Path(output_html).write_text(html)
+    return output_html
+
+
+_TEMPLATE = r"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>GO-CAM Standard-Annotation Ratchet</title>
+<style>
+  :root{--bg:#0f1419;--panel:#1b232c;--line:#2c3742;--ink:#e6edf3;--muted:#8b98a5;
+        --keep:#3fb950;--drop:#e5534b;--accent:#58a6ff;--chip:#21303f;}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);
+       font:14px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif}
+  header{padding:20px 24px;border-bottom:1px solid var(--line)}
+  h1{margin:0;font-size:20px}
+  .sub{color:var(--muted);font-size:13px;margin-top:4px}
+  .cards{display:flex;gap:12px;flex-wrap:wrap;margin:16px 24px;align-items:stretch}
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:10px;
+        padding:12px 16px;min-width:140px;flex:1}
+  .card .n{font-size:24px;font-weight:700}
+  .card .l{color:var(--muted);font-size:12px;margin-top:2px}
+  .card .arrow{color:var(--muted);font-size:18px;align-self:center}
+  .wrap{display:flex;gap:16px;padding:8px 24px 8px;align-items:flex-start;flex-wrap:wrap}
+  .col{flex:1;min-width:420px}
+  section{padding:8px 24px 24px}
+  h2{font-size:13px;text-transform:uppercase;letter-spacing:.06em;color:var(--muted);
+     margin:18px 0 8px}
+  .stage{background:var(--panel);border:1px solid var(--line);border-radius:8px;
+         padding:8px 10px;margin-bottom:6px;cursor:pointer;transition:border-color .1s}
+  .stage:hover{border-color:var(--accent)}
+  .stage.sel{border-color:var(--accent);box-shadow:0 0 0 1px var(--accent) inset}
+  .stage .top{display:flex;justify-content:space-between;gap:8px;align-items:baseline}
+  .stage .name{font-weight:600}
+  .stage .tsv{color:var(--muted);font-weight:400;font-size:12px}
+  .stage .nums{font-variant-numeric:tabular-nums;font-size:12px;color:var(--muted);white-space:nowrap}
+  .stage .nums b{color:var(--drop)}
+  .bar{height:9px;border-radius:5px;background:#0c1117;margin-top:6px;overflow:hidden;display:flex}
+  .bar .k{background:var(--keep)} .bar .d{background:var(--drop)}
+  .panel{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:16px;position:sticky;top:12px}
+  .panel .desc{color:var(--muted);margin:6px 0 14px;font-size:13px}
+  table{width:100%;border-collapse:collapse;font-size:13px}
+  td,th{padding:5px 6px;border-bottom:1px solid var(--line);vertical-align:top;text-align:left}
+  th{color:var(--muted);font-weight:600;font-size:11px;text-transform:uppercase;letter-spacing:.04em;cursor:pointer}
+  .c{text-align:right;font-variant-numeric:tabular-nums;white-space:nowrap}
+  .ptbl .c{color:var(--accent);font-weight:600}
+  .pbar{height:6px;background:var(--accent);border-radius:3px;margin-top:4px;opacity:.5}
+  .ex{color:var(--muted);font-size:11px;margin-top:3px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+  .ex span{background:var(--chip);padding:1px 5px;border-radius:4px;margin-right:4px;display:inline-block;margin-top:2px}
+  input{background:#0c1117;border:1px solid var(--line);color:var(--ink);border-radius:6px;
+        padding:6px 9px;width:100%;margin-bottom:10px;font-size:13px}
+  .empty{color:var(--muted);font-style:italic}
+  .foot{color:var(--muted);font-size:11px;padding:0 24px 24px}
+  a{color:var(--accent);text-decoration:none} a:hover{text-decoration:underline}
+  .axisbtns{display:flex;gap:8px;margin-bottom:10px;flex-wrap:wrap}
+  .btn{background:var(--panel);border:1px solid var(--line);color:var(--ink);border-radius:7px;
+       padding:6px 12px;cursor:pointer;font-size:13px}
+  .btn.on{border-color:var(--accent);color:var(--accent)}
+  .mwrap{display:flex;gap:16px;align-items:flex-start;flex-wrap:wrap}
+  .mcol{flex:1;min-width:420px}
+  .axtbl tr{cursor:pointer} .axtbl tr.sel td{background:#101a26}
+  .mini{display:flex;gap:3px;align-items:flex-end;height:38px;margin:4px 0 2px}
+  .mini .b{flex:1;background:var(--accent);border-radius:2px 2px 0 0;min-height:2px;opacity:.7;position:relative}
+  .mini .lbl{color:var(--muted);font-size:10px;text-align:center}
+  .ratepill{display:inline-block;min-width:42px;text-align:right;font-variant-numeric:tabular-nums}
+  .ubar{height:6px;background:#0c1117;border-radius:3px;margin-top:3px;overflow:hidden}
+  .ubar>div{height:100%;background:var(--keep)}
+</style>
+</head>
+<body>
+<header>
+  <h1>GO-CAM Standard-Annotation Ratchet</h1>
+  <div class="sub" id="sub"></div>
+</header>
+<div class="cards" id="cards"></div>
+<div class="wrap">
+  <div class="col">
+    <h2>Phase A &mdash; model ratchet</h2><div id="phaseA"></div>
+    <h2>Phase B &mdash; annotation-unit ratchet</h2><div id="phaseB"></div>
+  </div>
+  <div class="col">
+    <div class="panel">
+      <div id="dd-head"><b>Select a stage</b></div>
+      <div class="desc" id="dd-desc">Click any rule on the left to see what it filtered out and the most common offending patterns.</div>
+      <input id="filter" placeholder="filter patterns…" oninput="renderPatterns()" style="display:none">
+      <div id="dd-body"></div>
+    </div>
+  </div>
+</div>
+<section id="models-sec" style="display:none">
+  <h2>Explore models</h2>
+  <div class="sub" id="models-head" style="margin-bottom:10px"></div>
+  <div class="mwrap">
+    <div class="mcol">
+      <div class="axisbtns">
+        <button class="btn" id="ax-modelstate" onclick="setAxis('modelstate')">By modelstate</button>
+        <button class="btn" id="ax-group" onclick="setAxis('group')">By editorial group</button>
+      </div>
+      <div id="axis-table"></div>
+    </div>
+    <div class="mcol">
+      <div class="panel">
+        <div style="margin-bottom:10px"><b>Percent of model passing</b> (per-model unit pass rate)</div>
+        <div class="mini" id="hist"></div>
+        <div id="model-list-head" style="margin-top:14px"><b>Models</b> <span class="muted" id="ml-sub"></span></div>
+        <input id="mfilter" placeholder="filter models…" oninput="renderModelList()" style="margin-top:8px">
+        <div id="model-list"></div>
+      </div>
+    </div>
+  </div>
+</section>
+<div class="foot" id="foot"></div>
+<script>
+const DATA = /*__DATA__*/;
+let SEL = null, AXIS = 'modelstate', AXVAL = null;
+let patSort={key:'count',dir:-1}, axisSort={key:'models',dir:-1}, mlSort={key:'total',dir:-1};
+function sArrow(st,k){return st.key===k?(st.dir<0?' ▾':' ▴'):'';}
+function sortPat(k){if(patSort.key===k)patSort.dir=-patSort.dir;else{patSort.key=k;patSort.dir=(k==='label')?1:-1;}renderPatterns();}
+function sortAxis(k){if(axisSort.key===k)axisSort.dir=-axisSort.dir;else{axisSort.key=k;axisSort.dir=(k==='value')?1:-1;}renderAxisTable();}
+function sortMl(k){if(mlSort.key===k)mlSort.dir=-mlSort.dir;else{mlSort.key=k;mlSort.dir=(k==='model')?1:-1;}renderModelList();}
+function noctua(id){return DATA.noctua_base+'gomodel:'+id;}
+
+function fmt(n){return n.toLocaleString();}
+function pct(a,b){return b? (100*a/b).toFixed(1)+'%' : '—';}
+function el(tag, cls, html){const e=document.createElement(tag); if(cls)e.className=cls; if(html!=null)e.innerHTML=html; return e;}
+function esc(s){return String(s).replace(/[&<>]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]));}
+
+function cards(){
+  const h=DATA.headline, c=document.getElementById('cards');
+  const items=[['Models (S0)',h.s0_models],['Candidate models',h.candidate_models],
+               ['Annotation units',h.annotation_units],['Standard annotations',h.standard_annotations]];
+  items.forEach((it,i)=>{
+    c.appendChild(el('div','card','<div class="n">'+fmt(it[1])+'</div><div class="l">'+it[0]+'</div>'));
+    if(i<items.length-1) c.appendChild(el('div','arrow','→'));
+  });
+  document.getElementById('sub').textContent=
+    'run: '+DATA.label+'  ·  '+DATA.stages.length+' stages  ·  '
+    +fmt(h.s0_models)+' models → '+fmt(h.standard_annotations)+' standard annotations';
+}
+
+/* ---------- funnel + per-rule drill-down ---------- */
+function stageRow(s, phaseS0){
+  const row=el('div','stage'); row.dataset.id=s.index+'-'+s.rule_id;
+  const keepPct=100*s.out/phaseS0, dropPct=100*s.removed/phaseS0;
+  row.innerHTML =
+    '<div class="top"><span class="name">'+s.rule_id+
+      (s.tsv?' <span class="tsv">#'+s.tsv+'</span>':'')+'</span>'+
+      '<span class="nums">'+fmt(s['in'])+' &minus;<b>'+fmt(s.removed)+'</b> = '+fmt(s.out)+'</span></div>'+
+    '<div class="bar"><div class="k" style="width:'+keepPct+'%"></div>'+
+      '<div class="d" style="width:'+dropPct+'%"></div></div>';
+  row.onclick=()=>selectStage(s);
+  return row;
+}
+function funnel(){
+  const A=DATA.stages.filter(s=>s.phase==='A'), B=DATA.stages.filter(s=>s.phase==='B');
+  const a0=A.length?A[0]['in']:1, b0=B.length?B[0]['in']:1;
+  A.forEach(s=>document.getElementById('phaseA').appendChild(stageRow(s,a0)));
+  B.forEach(s=>document.getElementById('phaseB').appendChild(stageRow(s,b0)));
+}
+function selectStage(s){
+  SEL=s;
+  document.querySelectorAll('.stage').forEach(r=>r.classList.toggle('sel', r.dataset.id===s.index+'-'+s.rule_id));
+  document.getElementById('dd-head').innerHTML='<b>'+s.rule_id+'</b>'+(s.tsv?' &middot; rule #'+s.tsv:'')+
+    ' &middot; '+(s.kind||'')+' &middot; <span style="color:var(--drop)">'+fmt(s.removed)+' removed</span>';
+  document.getElementById('dd-desc').textContent=s.description||'';
+  const f=document.getElementById('filter'); f.style.display=s.patterns.length?'block':'none'; f.value='';
+  renderPatterns();
+}
+function renderPatterns(){
+  const body=document.getElementById('dd-body'); body.innerHTML='';
+  if(!SEL){return;}
+  if(!SEL.patterns.length){body.appendChild(el('div','empty','No per-edge detail (membership/structural filter).')); return;}
+  const q=(document.getElementById('filter').value||'').toLowerCase();
+  let pats=SEL.patterns.filter(p=>!q||p.label.toLowerCase().includes(q));
+  const max=Math.max.apply(null,SEL.patterns.map(p=>p.count));
+  pats=pats.slice().sort((a,b)=> patSort.dir*(patSort.key==='label'? a.label.localeCompare(b.label) : a.count-b.count));
+  const tbl=el('table','ptbl');
+  tbl.innerHTML='<tr><th onclick="sortPat(\'label\')">Pattern'+sArrow(patSort,'label')+
+    '</th><th class="c" onclick="sortPat(\'count\')">Count'+sArrow(patSort,'count')+'</th></tr>';
+  pats.forEach(p=>{
+    let ex=''; if(p.sources&&p.sources.length) ex+=p.sources.map(s=>'<span>'+esc(s)+'</span>').join('');
+    if(p.examples&&p.examples.length) ex+='<div class="ex">'+p.examples.map(e=>'<a href="'+noctua(e)+'" target="_blank" rel="noopener"><span>'+esc(e)+'</span></a>').join('')+'</div>';
+    const tr=el('tr');
+    tr.innerHTML='<td>'+esc(p.label)+'<div class="pbar" style="width:'+(100*p.count/max)+'%"></div>'+ex+'</td>'+
+      '<td class="c">'+fmt(p.count)+'</td>';
+    tbl.appendChild(tr);
+  });
+  body.appendChild(tbl);
+}
+
+/* ---------- explorable model axes ---------- */
+const M=DATA.models;
+function mState(m){return M.modelstates[m[1]];}
+function mGroups(m){return m[2].map(i=>M.groups[i]);}
+
+function computeAxis(axis){
+  const agg=new Map();
+  M.rows.forEach(m=>{
+    const keys = axis==='modelstate' ? [mState(m)] : mGroups(m);
+    keys.forEach(k=>{
+      let a=agg.get(k); if(!a){a={value:k,models:0,passing:0,tU:0,pU:0}; agg.set(k,a);}
+      a.models++; if(m[4]>0)a.passing++; a.tU+=m[3]; a.pU+=m[4];
+    });
+  });
+  return [...agg.values()].sort((x,y)=>y.models-x.models);
+}
+function setAxis(axis){
+  AXIS=axis; AXVAL=null;
+  document.getElementById('ax-modelstate').classList.toggle('on',axis==='modelstate');
+  document.getElementById('ax-group').classList.toggle('on',axis==='group');
+  renderAxisTable();
+  renderModelList();
+}
+function renderAxisTable(){
+  let rows=computeAxis(AXIS);
+  const max=Math.max.apply(null,rows.map(r=>r.models));
+  const rate=r=>r.tU?r.pU/r.tU:0;
+  rows=rows.slice().sort((a,b)=>{
+    let v; if(axisSort.key==='value')v=a.value.localeCompare(b.value);
+    else if(axisSort.key==='rate')v=rate(a)-rate(b);
+    else v=a[axisSort.key]-b[axisSort.key];
+    return axisSort.dir*v;
+  });
+  const tbl=el('table','axtbl');
+  tbl.innerHTML='<tr><th onclick="sortAxis(\'value\')">'+(AXIS==='modelstate'?'Modelstate':'Editorial group')+sArrow(axisSort,'value')+
+    '</th><th class="c" onclick="sortAxis(\'models\')">Models'+sArrow(axisSort,'models')+
+    '</th><th class="c" onclick="sortAxis(\'passing\')">Passing'+sArrow(axisSort,'passing')+
+    '</th><th class="c" onclick="sortAxis(\'rate\')">Unit pass rate'+sArrow(axisSort,'rate')+'</th></tr>';
+  rows.forEach(r=>{
+    const tr=el('tr'); if(r.value===AXVAL)tr.classList.add('sel');
+    tr.innerHTML='<td>'+esc(r.value)+'<div class="pbar" style="width:'+(100*r.models/max)+'%"></div></td>'+
+      '<td class="c">'+fmt(r.models)+'</td>'+
+      '<td class="c">'+fmt(r.passing)+' <span class="muted">('+pct(r.passing,r.models)+')</span></td>'+
+      '<td class="c"><span class="ratepill">'+pct(r.pU,r.tU)+'</span>'+
+        '<div class="ubar"><div style="width:'+(r.tU?100*r.pU/r.tU:0)+'%"></div></div></td>';
+    tr.onclick=()=>{AXVAL=r.value; renderAxisTable(); renderModelList();};
+    tbl.appendChild(tr);
+  });
+  const c=document.getElementById('axis-table'); c.innerHTML=''; c.appendChild(tbl);
+}
+function renderModelList(){
+  const head=document.getElementById('ml-sub'), c=document.getElementById('model-list'); c.innerHTML='';
+  let rows=M.rows;
+  if(AXVAL!==null) rows=rows.filter(m=> (AXIS==='modelstate'? mState(m)===AXVAL : mGroups(m).includes(AXVAL)));
+  const q=(document.getElementById('mfilter').value||'').toLowerCase();
+  if(q) rows=rows.filter(m=>m[0].toLowerCase().includes(q));
+  const rrate=m=>m[3]?m[4]/m[3]:0;
+  rows=rows.slice().sort((a,b)=>{
+    let v; if(mlSort.key==='model')v=a[0].localeCompare(b[0]);
+    else if(mlSort.key==='pass')v=rrate(a)-rrate(b);
+    else v=a[3]-b[3];
+    return mlSort.dir*v;
+  });
+  const CAP=300, shown=rows.slice(0,CAP);
+  head.textContent=(AXVAL!==null?'in “'+AXVAL+'” ':'')+'· '+fmt(rows.length)+' models'+(rows.length>CAP?' (showing '+CAP+')':'');
+  const tbl=el('table');
+  tbl.innerHTML='<tr><th onclick="sortMl(\'model\')">Model'+sArrow(mlSort,'model')+
+    '</th><th class="c" onclick="sortMl(\'total\')">Std/Total'+sArrow(mlSort,'total')+
+    '</th><th class="c" onclick="sortMl(\'pass\')">Pass'+sArrow(mlSort,'pass')+'</th></tr>';
+  shown.forEach(m=>{
+    const rate=m[3]?100*m[4]/m[3]:0;
+    const tr=el('tr');
+    tr.innerHTML='<td><a href="'+noctua(m[0])+'" target="_blank" rel="noopener">'+esc(m[0])+'</a>'+
+        ' <span class="muted" style="font-size:11px">'+esc(mState(m))+'</span></td>'+
+      '<td class="c">'+fmt(m[4])+'/'+fmt(m[3])+'</td>'+
+      '<td class="c"><span class="ratepill">'+(m[3]?rate.toFixed(0)+'%':'—')+'</span>'+
+        '<div class="ubar"><div style="width:'+rate+'%"></div></div></td>';
+    tbl.appendChild(tr);
+  });
+  c.appendChild(tbl);
+}
+function histogram(){
+  const h=M.histogram, keys=Object.keys(h), max=Math.max.apply(null,keys.map(k=>h[k]))||1;
+  const c=document.getElementById('hist'); c.innerHTML='';
+  keys.forEach(k=>{
+    const col=el('div'); col.style.flex='1'; col.style.textAlign='center';
+    col.innerHTML='<div class="b" title="'+h[k]+' models" style="height:'+(100*h[k]/max)+'%"></div>'+
+      '<div class="lbl">'+k+'<br>'+fmt(h[k])+'</div>';
+    c.appendChild(col);
+  });
+}
+function models(){
+  if(!M){return;}
+  document.getElementById('models-sec').style.display='block';
+  document.getElementById('models-head').innerHTML=
+    '<b>'+fmt(M.n)+'</b> candidate models · <b>'+fmt(M.passing)+'</b> passing (≥1 standard annotation, '+
+    pct(M.passing,M.n)+') · '+fmt(M.passing_units)+' / '+fmt(M.total_units)+' units standard ('+
+    pct(M.passing_units,M.total_units)+'). Model ids link to the Noctua graph editor.';
+  histogram(); setAxis('modelstate');
+}
+
+cards(); funnel(); models();
+document.getElementById('foot').innerHTML=
+  'Generated by gocam_unwinder.ratchet.dashboard · self-contained (no network) · '+
+  'funnel bars scaled to each phase’s starting set (green = surviving, red = removed).';
+(function(){const b=DATA.stages.filter(s=>s.phase==='B'); if(b.length){b.slice().sort((x,y)=>y.removed-x.removed); selectStage(b.slice().sort((x,y)=>y.removed-x.removed)[0]);}})();
+</script>
+</body>
+</html>
+"""
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        prog="python -m gocam_unwinder.ratchet.dashboard",
+        description="Build a self-contained HTML dashboard from a ratchet run.")
+    ap.add_argument("--out-dir", required=True, help="Ratchet output dir (summary.tsv + rejects/ + model_stats.jsonl).")
+    ap.add_argument("--rules-dir", default="rules", help="Rule manifests dir (for descriptions).")
+    ap.add_argument("--groups-yaml", help="go-site groups.yaml to resolve group URIs to labels.")
+    ap.add_argument("--noctua-base", default=DEFAULT_NOCTUA_BASE,
+                    help="Noctua editor base URL for model links.")
+    ap.add_argument("--output", required=True, help="Path to write dashboard.html.")
+    args = ap.parse_args(argv)
+    path = build_dashboard(args.out_dir, args.rules_dir, args.output,
+                           groups_yaml=args.groups_yaml, noctua_base=args.noctua_base)
+    print(f"wrote {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/gocam_unwinder/ratchet/engine.py
+++ b/src/gocam_unwinder/ratchet/engine.py
@@ -1,0 +1,92 @@
+"""Rule adapters: the two ways a rule decides keep/remove for an item, both
+behind a uniform ``apply(item, ctx) -> Verdict``. Per the engine decision,
+models are processed per-file in-process with rdflib (no Blazegraph journal, no
+``arq`` subprocess-per-file).
+
+  * ``PythonRuleAdapter`` wraps a Python predicate ``(ctx, item) -> Verdict``.
+    This is how the existing ontology-aware ``gocam_ttl`` checks are reused as
+    rules without rewriting them as SPARQL.
+  * ``SparqlRuleAdapter`` runs a SPARQL ASK/SELECT over the item's model graph
+    and maps the result to a verdict. This is how new/simple structural rules
+    (the noctua-models ``.rq`` style) are authored as data, no code.
+"""
+
+from pathlib import Path
+
+import rdflib
+
+from .core import Verdict
+
+
+class PythonRuleAdapter:
+    """Adapt a Python predicate ``func(ctx, item) -> Verdict`` into a rule.
+
+    ``reason`` is the default removal reason, filled in when the predicate
+    returns a removal without its own reason.
+    """
+
+    def __init__(self, func, reason=None):
+        self.func = func
+        self.reason = reason
+
+    def apply(self, item, ctx=None) -> Verdict:
+        verdict = self.func(ctx, item)
+        if not verdict.keep and verdict.reason is None and self.reason:
+            verdict.reason = self.reason
+        return verdict
+
+
+class SparqlRuleAdapter:
+    """Run a SPARQL query over the item's model TTL and decide keep/remove.
+
+    remove_when:
+      "ask_true"        -- remove when the ASK returns True (the query describes
+                           a disqualifying violation).
+      "ask_false"       -- remove when the ASK returns False (the query asserts a
+                           required property the item must have).
+      "select_nonempty" -- remove when a SELECT returns one or more rows.
+    """
+
+    def __init__(self, query=None, query_path=None, remove_when="ask_true",
+                 reason="sparql_rule"):
+        if query is None and query_path is None:
+            raise ValueError("SparqlRuleAdapter needs query or query_path")
+        if query is None:
+            query = Path(query_path).read_text()
+        self.query = query
+        self.remove_when = remove_when
+        self.reason = reason
+
+    def apply(self, item, ctx=None) -> Verdict:
+        graph = rdflib.Graph()
+        graph.parse(str(item.path), format="ttl")
+        result = graph.query(self.query)
+
+        if self.remove_when in ("ask_true", "ask_false"):
+            ask = bool(result.askAnswer)
+            violated = ask if self.remove_when == "ask_true" else (not ask)
+        elif self.remove_when == "select_nonempty":
+            violated = len(result) > 0
+        else:
+            raise ValueError(f"unknown remove_when {self.remove_when!r}")
+
+        if violated:
+            return Verdict.reject(self.reason)
+        return Verdict.survive()
+
+
+def resolve_adapter(rule, python_registry=None):
+    """Bind a ``Rule`` (manifest data) to a runnable adapter.
+
+    python_registry -- dict ``{entrypoint_name: callable(ctx, item) -> Verdict}``
+                       used to resolve ``kind: python`` rules.
+    """
+    if rule.kind == "sparql":
+        return SparqlRuleAdapter(query_path=rule.query_path,
+                                 remove_when=rule.remove_when, reason=rule.id)
+    python_registry = python_registry or {}
+    func = python_registry.get(rule.entrypoint)
+    if func is None:
+        raise KeyError(
+            f"rule {rule.id!r}: no python entrypoint {rule.entrypoint!r} registered")
+    return PythonRuleAdapter(func, reason=rule.id)

--- a/src/gocam_unwinder/ratchet/model_rules.py
+++ b/src/gocam_unwinder/ratchet/model_rules.py
@@ -1,0 +1,155 @@
+"""Phase A model-level ratchet rules.
+
+These operate on whole-model items: ``item.id`` is the model's filename stem
+(== model id) and ``item.path`` is the model ``.ttl``. Two of the three gates
+are filename-/id-only (no graph parse); ``modelstate_gate`` parses the model
+with rdflib but needs no ontology, so all of Phase A runs without the GO/RO
+ontologies loaded.
+
+A model rule is a callable ``(ctx, item) -> Verdict`` (the registry signature).
+The two parameterized gates are built by factories so the CLI can close over
+runtime config (skip prefixes, the consumed true-GO-CAM id set).
+"""
+
+import json
+from pathlib import Path
+
+import rdflib
+
+from .core import Verdict
+
+# Canonical published true-GO-CAM classification report (one JSONL line per
+# model: {"model_id", "status": "success"|"filtered", ...}; "success" == a true
+# GO-CAM). Relative to a pipeline-from-goa skyhook base, e.g.
+# https://skyhook.geneontology.io/pipeline-from-goa/main
+TRUE_GOCAM_REPORT_PATH = "reports/go-cam/02-filter.jsonl"
+
+LEGO_MODELSTATE = rdflib.URIRef("http://geneontology.org/lego/modelstate")
+
+
+def _model_state(graph: rdflib.Graph):
+    """Return the lego:modelstate of the model-level owl:Ontology subject, or None."""
+    for model in graph.subjects(rdflib.RDF.type, rdflib.OWL.Ontology):
+        for state in graph.objects(model, LEGO_MODELSTATE):
+            return str(state)
+    return None
+
+
+def modelstate_gate(ctx, item, drop_states=("delete",)) -> Verdict:
+    """Drop models whose lego:modelstate is in ``drop_states`` (default: delete).
+
+    Mirrors the ``modelstate == "delete"`` skip in gocam_ttl's main(). A model
+    with no modelstate triple is kept (only explicit drop states are removed).
+    """
+    graph = rdflib.Graph()
+    graph.parse(str(item.path), format="ttl")
+    state = _model_state(graph)
+    if state in drop_states:
+        return Verdict.reject("modelstate_" + state, modelstate=state)
+    return Verdict.survive()
+
+
+def make_skip_prefix_gate(prefixes):
+    """Build a gate that drops models whose filename starts with any prefix."""
+    prefixes = tuple(prefixes or ())
+
+    def skip_prefix_gate(ctx, item) -> Verdict:
+        name = item.path.name if item.path else (item.id + ".ttl")
+        for prefix in prefixes:
+            if name.startswith(prefix):
+                return Verdict.reject("skip_prefix", prefix=prefix)
+        return Verdict.survive()
+
+    return skip_prefix_gate
+
+
+def make_not_true_gocam_gate(true_gocam_ids):
+    """Build R1: drop models whose id is in the consumed true-GO-CAM set.
+
+    Survivors are exactly the models that are NOT true GO-CAMs (the candidate
+    pool for standard annotations).
+    """
+    true_gocam_ids = set(true_gocam_ids or ())
+
+    def not_true_gocam_gate(ctx, item) -> Verdict:
+        if item.id in true_gocam_ids:
+            return Verdict.reject("is_true_gocam")
+        return Verdict.survive()
+
+    return not_true_gocam_gate
+
+
+def parse_true_gocam_report(text) -> set:
+    """Return the set of true-GO-CAM model ids from a filter-report JSONL body.
+
+    Each line is ``{"model_id": ..., "status": "success"|"filtered", ...}``;
+    a true GO-CAM is one with ``status == "success"`` (production + pathway-like).
+    """
+    ids = set()
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        rec = json.loads(line)
+        if rec.get("status") == "success":
+            ids.add(rec["model_id"])
+    return ids
+
+
+def _load_true_gocam_ids_from_url(url) -> set:
+    """Fetch true-GO-CAM ids over HTTP. A URL ending in ``.jsonl`` is taken as
+    the filter report itself; otherwise it is treated as a pipeline-from-goa
+    skyhook base and the canonical report path is appended.
+
+    A non-default User-Agent is set because skyhook is Cloudflare-fronted and
+    403s the default ``Python-urllib`` agent.
+    """
+    from urllib.request import Request, urlopen
+    if not url.endswith(".jsonl"):
+        url = url.rstrip("/") + "/" + TRUE_GOCAM_REPORT_PATH
+    req = Request(url, headers={"User-Agent": "Mozilla/5.0 (gocam-evidence-unwinder ratchet)"})
+    with urlopen(req, timeout=120) as resp:
+        return parse_true_gocam_report(resp.read().decode("utf-8"))
+
+
+def load_true_gocam_ids(source) -> set:
+    """Load the set of true-GO-CAM model ids (filename stems) to exclude (R1).
+
+    ``source`` may be:
+      * an ``http(s)://`` URL -- either a filter-report ``.jsonl`` directly, or a
+        pipeline-from-goa skyhook base (e.g.
+        ``https://skyhook.geneontology.io/pipeline-from-goa/main``), to which
+        ``reports/go-cam/02-filter.jsonl`` is appended;
+      * a directory whose file stems are model ids (e.g. a local ``go-cams/json/``);
+      * a local filter-report ``.jsonl`` file (parsed by status);
+      * a plain text file with one model id per line (``#`` comments ignored).
+    """
+    s = str(source)
+    if s.startswith("http://") or s.startswith("https://"):
+        return _load_true_gocam_ids_from_url(s)
+    p = Path(s)
+    if p.is_dir():
+        return {f.stem for f in p.iterdir() if f.is_file()}
+    if p.suffix == ".jsonl":
+        return parse_true_gocam_report(p.read_text())
+    ids = set()
+    with open(p) as fh:
+        for line in fh:
+            line = line.strip()
+            if line and not line.startswith("#"):
+                ids.add(line)
+    return ids
+
+
+def build_model_rule_registry(skip_prefixes=None, true_gocam_ids=None) -> dict:
+    """Map Phase A rule entrypoint names to runnable callables.
+
+    Used by the CLI to resolve ``kind: python`` model rules. The parameterized
+    gates close over runtime config; both are safe no-ops when their config is
+    empty (no prefixes / empty id set).
+    """
+    return {
+        "modelstate_gate": modelstate_gate,
+        "skip_prefix_gate": make_skip_prefix_gate(skip_prefixes),
+        "not_true_gocam_gate": make_not_true_gocam_gate(true_gocam_ids),
+    }

--- a/src/gocam_unwinder/ratchet/rules.py
+++ b/src/gocam_unwinder/ratchet/rules.py
@@ -1,0 +1,111 @@
+"""Rule manifests: rules are data, stored as ``rules/NN-name/rule.yaml``.
+
+A rule directory holds a ``rule.yaml`` describing the rule and, for SPARQL
+rules, a sibling ``query.rq``. ``load_rules`` discovers rule dirs and orders
+them by directory name -- a zero-padded ``NN-`` prefix makes lexical order equal
+execution order. The runner walks them in order; adding a rule needs no code
+change to the runner.
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional
+
+import yaml
+
+PHASES = ("model", "unit")
+KINDS = ("python", "sparql")
+REMOVE_WHEN = ("ask_true", "ask_false", "select_nonempty")
+
+
+@dataclass
+class Rule:
+    """Parsed ``rule.yaml`` -- pure manifest data, resolved to an adapter later.
+
+    id          -- stable rule key (matches a ``failed_checks`` key where one
+                   exists). Used in report rows and output filenames.
+    phase       -- "model" (Phase A) or "unit" (Phase B).
+    kind        -- "python" (a registered predicate) or "sparql" (a query.rq).
+    stage       -- cost tier; only affects ordering hints within a phase.
+    tsv         -- std_annot_rules.tsv number, or None.
+    entrypoint  -- python: callable name in the rule registry. sparql: unused.
+    inputs      -- declared dependencies (e.g. ["go", "ro", "gp_allowlist",
+                   "true_gocam_set"]); informational + used by the CLI to fail
+                   fast if an input is missing.
+    remove_when -- sparql: how the query result maps to a removal.
+    """
+
+    id: str
+    phase: str
+    kind: str
+    dir: Path
+    stage: int = 0
+    tsv: Optional[int] = None
+    entrypoint: Optional[str] = None
+    inputs: List[str] = field(default_factory=list)
+    description: str = ""
+    enabled: bool = True
+    remove_when: str = "ask_true"
+    order_key: str = ""
+
+    @property
+    def query_path(self) -> Path:
+        return self.dir / "query.rq"
+
+
+def _parse_rule(rule_dir: Path) -> Rule:
+    manifest = rule_dir / "rule.yaml"
+    with open(manifest) as fh:
+        data = yaml.safe_load(fh) or {}
+
+    if "id" not in data:
+        raise ValueError(f"{manifest}: missing required 'id'")
+    phase = data.get("phase")
+    if phase not in PHASES:
+        raise ValueError(f"{manifest}: phase must be one of {PHASES}, got {phase!r}")
+    kind = data.get("kind")
+    if kind not in KINDS:
+        raise ValueError(f"{manifest}: kind must be one of {KINDS}, got {kind!r}")
+    remove_when = data.get("remove_when", "ask_true")
+    if remove_when not in REMOVE_WHEN:
+        raise ValueError(
+            f"{manifest}: remove_when must be one of {REMOVE_WHEN}, got {remove_when!r}")
+    if kind == "sparql" and not (rule_dir / "query.rq").exists():
+        raise ValueError(f"{manifest}: kind 'sparql' requires a sibling query.rq")
+    if kind == "python" and not data.get("entrypoint"):
+        raise ValueError(f"{manifest}: kind 'python' requires an 'entrypoint'")
+
+    return Rule(
+        id=data["id"],
+        phase=phase,
+        kind=kind,
+        dir=rule_dir,
+        stage=int(data.get("stage", 0)),
+        tsv=data.get("tsv"),
+        entrypoint=data.get("entrypoint"),
+        inputs=list(data.get("inputs", []) or []),
+        description=data.get("description", "") or "",
+        enabled=bool(data.get("enabled", True)),
+        remove_when=remove_when,
+        order_key=rule_dir.name,
+    )
+
+
+def load_rules(rules_dir, phase: Optional[str] = None,
+               include_disabled: bool = False) -> List[Rule]:
+    """Load rules under ``rules_dir``, ordered by directory name.
+
+    phase            -- if given ("model"|"unit"), only that phase's rules.
+    include_disabled -- if False (default), drop rules with ``enabled: false``.
+    """
+    rules_dir = Path(rules_dir)
+    rules = []
+    for manifest in sorted(rules_dir.glob("*/rule.yaml"),
+                           key=lambda p: p.parent.name):
+        rule = _parse_rule(manifest.parent)
+        if not include_disabled and not rule.enabled:
+            continue
+        if phase is not None and rule.phase != phase:
+            continue
+        rules.append(rule)
+    return rules

--- a/src/gocam_unwinder/ratchet/runner.py
+++ b/src/gocam_unwinder/ratchet/runner.py
@@ -1,0 +1,83 @@
+"""The staging engine: apply one rule to a set, partition survivors from
+rejects, and materialize the stage's outputs.
+
+Per stage, three artifacts are written into ``out_dir`` (mirroring the
+pipeline-from-goa convention of numbered stage dirs + sibling reject sets +
+per-stage JSONL reports):
+
+  * ``S{NN}-{id}.manifest.jsonl`` -- the surviving set ``Sn`` (carried forward).
+  * ``{NN}-{id}.rejects.tsv``     -- the items this rule removed, with reasons.
+  * ``reports/{NN}-{id}.jsonl``   -- one row per item: keep / remove / skip.
+
+The monotonic invariant (survivors are a subset of the input) is enforced here.
+"""
+
+import json
+from pathlib import Path
+
+from .core import Manifest, StageResult
+
+
+def run_stage(adapter, manifest: Manifest, *, out_dir, index: int,
+              stage_id: str, ctx=None) -> StageResult:
+    """Run one ratchet stage.
+
+    adapter  -- object with ``apply(item, ctx) -> Verdict``.
+    manifest -- the input set (survivors of the previous stage).
+    out_dir  -- directory to materialize this stage's outputs into.
+    index    -- integer stage number (zero-padded into the ``NN-`` prefix).
+    stage_id -- short rule id; used in filenames and the report ``rule`` column.
+    ctx      -- shared context handed to the adapter (e.g. a GoCamGraphBuilder).
+    """
+    out_dir = Path(out_dir)
+    reports_dir = out_dir / "reports"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+
+    survivors = []
+    rejected = []
+    report_rows = []
+    for item in manifest.items:
+        verdict = adapter.apply(item, ctx)
+        if verdict.skipped:
+            decision = "skip"
+        elif verdict.keep:
+            decision = "keep"
+        else:
+            decision = "remove"
+        row = {"id": item.id, "decision": decision, "rule": stage_id}
+        if verdict.reason:
+            row["reason"] = verdict.reason
+        row.update(verdict.detail)
+        report_rows.append(row)
+
+        if verdict.keep:
+            survivors.append(item)
+        else:
+            rejected.append((item, verdict))
+
+    # Monotonic invariant: a stage may only remove items, never add them.
+    assert len(survivors) <= len(manifest.items), "ratchet stage added items"
+
+    survivors_manifest = Manifest(survivors)
+    prefix = f"{index:02d}-{stage_id}"
+    survivors_manifest.write(out_dir / f"S{index:02d}-{stage_id}.manifest.jsonl")
+    _write_rejects_tsv(out_dir / f"{prefix}.rejects.tsv", rejected, stage_id)
+    _write_jsonl(reports_dir / f"{prefix}.jsonl", report_rows)
+
+    return StageResult(
+        index=index, stage_id=stage_id, survivors=survivors_manifest,
+        rejected=rejected, report_rows=report_rows, in_count=len(manifest.items))
+
+
+def _write_jsonl(path, rows) -> None:
+    with open(path, "w") as fh:
+        for row in rows:
+            fh.write(json.dumps(row) + "\n")
+
+
+def _write_rejects_tsv(path, rejected, stage_id) -> None:
+    with open(path, "w") as fh:
+        fh.write("id\trule\treason\tdetail\n")
+        for item, verdict in rejected:
+            detail = json.dumps(verdict.detail) if verdict.detail else ""
+            fh.write(f"{item.id}\t{stage_id}\t{verdict.reason or ''}\t{detail}\n")

--- a/src/gocam_unwinder/ratchet/summary.py
+++ b/src/gocam_unwinder/ratchet/summary.py
@@ -1,0 +1,21 @@
+"""Roll-up summary across all ratchet stages (Phase A model + Phase B unit).
+
+Writes a single TSV: one row per stage with in / removed / out counts, so the
+monotonic shrink is visible end to end. Consumes any object exposing
+``phase``, ``index``, ``rule_id``, ``in_count``, ``removed``, ``out_count``
+(see cli.StageStat).
+"""
+
+from pathlib import Path
+
+
+def write_summary(stages, path):
+    path = Path(path)
+    lines = ["Phase\tStage\tRule\tIn\tRemoved\tOut"]
+    for s in stages:
+        lines.append("\t".join([
+            s.phase, f"{s.index:02d}", s.rule_id,
+            str(s.in_count), str(s.removed), str(s.out_count),
+        ]))
+    path.write_text("\n".join(lines) + "\n")
+    return path

--- a/src/gocam_unwinder/ratchet/unit_rules.py
+++ b/src/gocam_unwinder/ratchet/unit_rules.py
@@ -1,0 +1,82 @@
+"""Phase B unit-level rules: wrap each per-check callable from gocam_ttl as a
+ratchet rule over a single annotation unit.
+
+A unit item carries the parsed model and one annotation in ``item.payload``
+(``gcg`` + ``annotation``) -- in-memory, not serialized. The shared ``ctx`` is
+the ``GoCamGraphBuilder`` (GO/RO loaded once). A unit rule removes the unit when
+its check flags one or more edges; RO-dependent checks SKIP (keep + record) when
+no RO ontology is loaded, mirroring gocam_ttl's gating.
+"""
+
+from pathlib import Path
+
+from .core import Item, Verdict
+
+# Checks that need the RO ontology; without it they would silently pass, so we
+# record them as skipped instead of a misleading "kept".
+RO_DEPENDENT = {"mf_causal_mf", "invalid_gp_bp_relation", "invalid_mf_bp_relation"}
+
+
+def make_unit_rule(check_key):
+    """Build a unit rule ``(ctx, item) -> Verdict`` for one check key.
+
+    ctx  -- the GoCamGraphBuilder (provides run_check / term_label / ro_ontology).
+    item -- item.payload has "gcg" (GoCamGraph) and "annotation" (StandardAnnotation).
+    """
+
+    def unit_rule(ctx, item):
+        builder = ctx
+        if check_key in RO_DEPENDENT and getattr(builder, "ro_ontology", None) is None:
+            return Verdict.skip(check_key + "_skipped_no_ro")
+
+        gcg = item.payload["gcg"]
+        annotation = item.payload["annotation"]
+        flagged = builder.run_check(check_key, gcg, annotation)
+        if flagged:
+            # Surface one offending edge in the report (sorted for determinism).
+            edge = annotation.edges[sorted(flagged)[0]]
+            return Verdict.reject(
+                check_key,
+                source=builder.term_label(edge.source_type),
+                predicate=builder.term_label(edge.property_uri),
+                target=builder.term_label(edge.target_type),
+                flagged_edges=len(flagged),
+            )
+        return Verdict.survive()
+
+    unit_rule.__name__ = "unit_rule_" + check_key
+    return unit_rule
+
+
+def parse_model_units(builder, ttl_path):
+    """Parse a model WITHOUT classifying; return ``(gcg, units)`` where ``units``
+    is one Item per raw annotation unit (connected-component subgraph). The
+    returned ``gcg`` carries model-level metadata (modelstate, groups, title)
+    for per-model stats."""
+    gcg = builder.parse_ttl(str(ttl_path), classify=False)
+    items = []
+    for index, annotation in enumerate(gcg.standard_annotations):
+        items.append(Item(
+            id=f"{gcg.model_id}#{index}",
+            path=Path(ttl_path),
+            meta={"model_id": gcg.model_id, "unit_index": index,
+                  "edges": len(annotation.edges)},
+            payload={"gcg": gcg, "annotation": annotation},
+        ))
+    return gcg, items
+
+
+def extract_units(builder, ttl_path):
+    """Return one Item per raw annotation unit (see ``parse_model_units``)."""
+    return parse_model_units(builder, ttl_path)[1]
+
+
+def build_unit_rule_registry(check_keys=None):
+    """Map unit-rule entrypoint names (``unit_<key>``) to callables.
+
+    Defaults to the full ordered check set from the builder. Used by the CLI to
+    resolve ``kind: python`` unit rules.
+    """
+    from ..gocam_ttl import GoCamGraphBuilder
+    keys = check_keys if check_keys is not None else GoCamGraphBuilder.UNIT_CHECK_KEYS
+    return {f"unit_{key}": make_unit_rule(key) for key in keys}

--- a/tests/test_ratchet_dashboard.py
+++ b/tests/test_ratchet_dashboard.py
@@ -1,0 +1,100 @@
+"""Tests for the self-contained HTML dashboard builder."""
+
+import json
+import re
+
+from gocam_unwinder.ratchet.dashboard import build_dashboard, build_data
+
+
+def _make_out_dir(tmp_path):
+    out = tmp_path / "out"
+    (out / "rejects").mkdir(parents=True)
+    (out / "summary.tsv").write_text(
+        "Phase\tStage\tRule\tIn\tRemoved\tOut\n"
+        "A\t01\tskip_prefix\t100\t10\t90\n"
+        "B\t04\tedge_without_evidence\t200\t5\t195\n")
+    (out / "rejects" / "01-skip_prefix.rejects.tsv").write_text(
+        "id\trule\treason\tdetail\n"
+        + "".join(f"m{i}\tskip_prefix\tskip_prefix\t"
+                 + json.dumps({"prefix": "SYNGO" if i % 2 else "R-HSA"}) + "\n"
+                 for i in range(10)))
+    (out / "rejects" / "04-edge_without_evidence.rejects.tsv").write_text(
+        "id\trule\treason\tdetail\n"
+        + "".join(f"http://m/A{i}#1\tedge_without_evidence\tedge_without_evidence\t"
+                 + json.dumps({"source": "x", "predicate": "part of",
+                               "target": "nucleus", "flagged_edges": 1}) + "\n"
+                 for i in range(5)))
+    return out
+
+
+def test_build_data_shapes(tmp_path):
+    out = _make_out_dir(tmp_path)
+    data = build_data(out, "rules")
+    assert data["headline"] == {
+        "s0_models": 100, "candidate_models": 90,
+        "annotation_units": 200, "standard_annotations": 195}
+    assert [s["rule_id"] for s in data["stages"]] == ["skip_prefix", "edge_without_evidence"]
+    sp = next(s for s in data["stages"] if s["rule_id"] == "skip_prefix")
+    labels = {p["label"]: p["count"] for p in sp["patterns"]}
+    assert labels == {"prefix: SYNGO": 5, "prefix: R-HSA": 5}
+    ewe = next(s for s in data["stages"] if s["rule_id"] == "edge_without_evidence")
+    assert ewe["patterns"][0]["label"] == "part of  →  nucleus"
+    assert ewe["patterns"][0]["count"] == 5
+    # real description pulled from rules/
+    assert "evidence" in ewe["description"].lower()
+
+
+def test_model_axes_and_group_resolution(tmp_path):
+    out = _make_out_dir(tmp_path)
+    (out / "model_stats.jsonl").write_text(
+        json.dumps({"model": "M1", "modelstate": "production",
+                    "groups": ["http://informatics.jax.org"],
+                    "total_units": 4, "passing_units": 4}) + "\n"
+        + json.dumps({"model": "M2", "modelstate": "development",
+                      "groups": ["http://informatics.jax.org"],
+                      "total_units": 2, "passing_units": 1}) + "\n"
+        + json.dumps({"model": "M3", "modelstate": "production",
+                      "groups": ["http://zfin.org"],
+                      "total_units": 3, "passing_units": 0}) + "\n")
+    groups = tmp_path / "groups.yaml"
+    groups.write_text(
+        "- {id: 'http://informatics.jax.org', label: MGI}\n"
+        "- {id: 'http://zfin.org', label: ZFIN}\n")
+
+    data = build_data(out, "rules", groups_yaml=str(groups),
+                      noctua_base="https://noctua.example/editor/graph/")
+    mb = data["models"]
+    assert mb["n"] == 3
+    assert mb["passing"] == 2                      # M1, M2 have >=1 passing unit
+    assert mb["passing_units"] == 5 and mb["total_units"] == 9
+    assert set(mb["modelstates"]) == {"production", "development"}
+    assert set(mb["groups"]) == {"MGI", "ZFIN"}    # URIs resolved to labels
+    assert mb["histogram"]["100%"] == 1 and mb["histogram"]["0%"] == 1
+    assert mb["histogram"]["26–50%"] == 1          # M2 = 50%
+    assert mb["noctua_base"] == "https://noctua.example/editor/graph/"
+    # compact rows: [model, stateIdx, [groupIdx], total, passing]
+    assert len(mb["rows"]) == 3
+    m1 = next(r for r in mb["rows"] if r[0] == "M1")
+    assert mb["groups"][m1[2][0]] == "MGI" and m1[3] == 4 and m1[4] == 4
+
+
+def test_no_model_stats_is_graceful(tmp_path):
+    out = _make_out_dir(tmp_path)  # no model_stats.jsonl
+    data = build_data(out, "rules")
+    assert data["models"] is None
+
+
+def test_build_dashboard_is_self_contained_html(tmp_path):
+    out = _make_out_dir(tmp_path)
+    html_path = tmp_path / "dashboard.html"
+    build_dashboard(out, "rules", html_path)
+    html = html_path.read_text()
+    assert "/*__DATA__*/" not in html          # placeholder substituted
+    assert html.lstrip().startswith("<!DOCTYPE html>")
+    # self-contained: no external scripts/stylesheets to fetch
+    assert "<script src=" not in html
+    assert 'rel="stylesheet"' not in html
+    # embedded DATA parses
+    m = re.search(r"const DATA = (\{.*?\});\nlet SEL", html, re.S)
+    data = json.loads(m.group(1))
+    assert data["headline"]["s0_models"] == 100

--- a/tests/test_ratchet_end_to_end.py
+++ b/tests/test_ratchet_end_to_end.py
@@ -1,0 +1,75 @@
+"""End-to-end two-level ratchet test (Task 7).
+
+Uses the session ``builder`` fixture (GO + RO + groups) so Phase B runs without
+re-parsing the GO ontology.
+"""
+
+import shutil
+from pathlib import Path
+
+from gocam_unwinder.ratchet.cli import run_ratchet
+
+RES = Path("resources/test")
+
+
+def _corpus(tmp_path, names):
+    d = tmp_path / "models"
+    d.mkdir()
+    for name in names:
+        shutil.copy(RES / name, d / name)
+    return d
+
+
+def test_end_to_end_two_level_shrink(tmp_path, builder):
+    models_dir = _corpus(tmp_path, [
+        "MGI_MGI_1100089.ttl",      # survives Phase A; has standard annotations
+        "R-HSA-9937080.ttl",        # removed by skip_prefix R-HSA
+        "SYNGO_5371.ttl",           # removed by skip_prefix SYNGO
+        "5b318d0900000481.ttl",     # removed by R1 (true-gocam)
+    ])
+    out_dir = tmp_path / "out"
+
+    result = run_ratchet(
+        models_dir, rules_dir="rules", out_dir=out_dir,
+        skip_prefixes=["SYNGO", "R-HSA"],
+        true_gocam_ids={"5b318d0900000481"},
+        builder=builder,
+    )
+
+    # Phase A: only the MGI model survives the model gates.
+    assert result.phase_a_survivors == ["MGI_MGI_1100089"]
+
+    # Within each phase, the in-counts are monotonically non-increasing.
+    a_in = [s.in_count for s in result.stages if s.phase == "A"]
+    b_in = [s.in_count for s in result.stages if s.phase == "B"]
+    assert a_in == sorted(a_in, reverse=True)
+    assert b_in == sorted(b_in, reverse=True)
+
+    # Phase B produced surviving annotation units, and they equal exactly the
+    # MGI model's standard annotations under the monolithic classifier.
+    assert len(result.final_units) >= 1
+    classified = builder.parse_ttl(str(RES / "MGI_MGI_1100089.ttl"), classify=True)
+    assert len(result.final_units) == len(classified.standard_annotations)
+
+    # Artifacts exist.
+    summary = out_dir / "summary.tsv"
+    assert summary.exists()
+    text = summary.read_text()
+    assert "model_has_activity_edges" in text          # Phase A SPARQL rule ran
+    assert "edge_without_evidence" in text              # Phase B unit rule ran
+    assert (out_dir / "SA-final.models.manifest.jsonl").exists()
+    assert (out_dir / "SB-final.units.manifest.jsonl").exists()
+    assert (out_dir / "phase-a" / "reports" / "01-skip_prefix.jsonl").exists()
+
+
+def test_phase_a_only_without_ontology(tmp_path):
+    """Without a builder/GO ontology, Phase A still runs and writes a summary;
+    Phase B is skipped."""
+    models_dir = _corpus(tmp_path, ["MGI_MGI_1100089.ttl", "SYNGO_5371.ttl"])
+    out_dir = tmp_path / "out"
+    result = run_ratchet(models_dir, rules_dir="rules", out_dir=out_dir,
+                         skip_prefixes=["SYNGO"])
+    assert result.phase_a_survivors == ["MGI_MGI_1100089"]
+    assert result.final_units == []
+    assert (out_dir / "summary.tsv").exists()
+    assert all(s.phase == "A" for s in result.stages)

--- a/tests/test_ratchet_engine.py
+++ b/tests/test_ratchet_engine.py
@@ -1,0 +1,103 @@
+"""Tests for the ratchet rule adapters (Task 3)."""
+
+import textwrap
+
+from gocam_unwinder.ratchet.core import Item, Verdict
+from gocam_unwinder.ratchet.engine import (
+    PythonRuleAdapter,
+    SparqlRuleAdapter,
+    resolve_adapter,
+)
+from gocam_unwinder.ratchet.rules import Rule
+
+EDGE_NO_EV_ASK = textwrap.dedent("""
+    PREFIX owl: <http://www.w3.org/2002/07/owl#>
+    PREFIX lego: <http://geneontology.org/lego/>
+    ASK {
+      ?ax a owl:Axiom ;
+          owl:annotatedSource ?s ;
+          owl:annotatedProperty ?p ;
+          owl:annotatedTarget ?t .
+      FILTER(STRSTARTS(STR(?p), "http://purl.obolibrary.org/obo/"))
+      FILTER NOT EXISTS { ?ax lego:evidence ?e }
+    }
+""")
+
+_MODEL = """@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+@prefix lego: <http://geneontology.org/lego/> .
+@prefix ex: <http://model.geneontology.org/ex/> .
+
+ex:s a owl:NamedIndividual .
+ex:t a owl:NamedIndividual .
+ex:ev a owl:NamedIndividual .
+[] a owl:Axiom ;
+   owl:annotatedSource ex:s ;
+   owl:annotatedProperty obo:RO_0002333 ;
+   owl:annotatedTarget ex:t %s .
+"""
+
+
+def _model(tmp_path, name, evidence):
+    ev = " ;\n   lego:evidence ex:ev" if evidence else ""
+    p = tmp_path / name
+    p.write_text(_MODEL % ev)
+    return Item(id=name, path=p)
+
+
+def test_sparql_ask_rule_removes_on_match(tmp_path):
+    rule = SparqlRuleAdapter(query=EDGE_NO_EV_ASK, remove_when="ask_true",
+                             reason="edge_without_evidence")
+    no_ev = _model(tmp_path, "no_ev.ttl", evidence=False)
+    has_ev = _model(tmp_path, "has_ev.ttl", evidence=True)
+
+    v = rule.apply(no_ev)
+    assert v.keep is False and v.reason == "edge_without_evidence"
+    assert rule.apply(has_ev).keep is True
+
+
+def test_sparql_ask_false_inverts(tmp_path):
+    # "ask_false" removes when the ASK is False (i.e. asserts a required shape).
+    rule = SparqlRuleAdapter(query=EDGE_NO_EV_ASK, remove_when="ask_false",
+                             reason="must_have_evidence_gap")
+    no_ev = _model(tmp_path, "no_ev.ttl", evidence=False)
+    has_ev = _model(tmp_path, "has_ev.ttl", evidence=True)
+    assert rule.apply(no_ev).keep is True   # ASK true -> not removed
+    assert rule.apply(has_ev).keep is False  # ASK false -> removed
+
+
+def test_python_rule_fills_default_reason():
+    def predicate(ctx, item):
+        if "bad" in item.id:
+            return Verdict.reject(None)  # no reason -> adapter supplies default
+        return Verdict.survive()
+
+    rule = PythonRuleAdapter(predicate, reason="is_bad")
+    assert rule.apply(Item(id="good")).keep is True
+    v = rule.apply(Item(id="bad1"))
+    assert v.keep is False and v.reason == "is_bad"
+
+
+def test_resolve_adapter_dispatches_python(tmp_path):
+    reg = {"my_fn": lambda ctx, item: Verdict.survive()}
+    prule = Rule(id="p", phase="unit", kind="python", dir=tmp_path, entrypoint="my_fn")
+    assert resolve_adapter(prule, reg).apply(Item(id="x")).keep is True
+
+
+def test_resolve_adapter_dispatches_sparql(tmp_path):
+    qdir = tmp_path / "sp"
+    qdir.mkdir()
+    (qdir / "query.rq").write_text(EDGE_NO_EV_ASK)
+    srule = Rule(id="edge_without_evidence", phase="unit", kind="sparql",
+                 dir=qdir, remove_when="ask_true")
+    item = _model(tmp_path, "n.ttl", evidence=False)
+    assert resolve_adapter(srule).apply(item).keep is False
+
+
+def test_resolve_adapter_unknown_python_entrypoint_raises(tmp_path):
+    prule = Rule(id="p", phase="unit", kind="python", dir=tmp_path, entrypoint="nope")
+    try:
+        resolve_adapter(prule, {})
+        assert False, "expected KeyError"
+    except KeyError as e:
+        assert "nope" in str(e)

--- a/tests/test_ratchet_model_rules.py
+++ b/tests/test_ratchet_model_rules.py
@@ -1,0 +1,138 @@
+"""Tests for Phase A model-level rules (Task 4)."""
+
+from pathlib import Path
+
+from gocam_unwinder.ratchet.core import Item, Manifest
+from gocam_unwinder.ratchet.engine import resolve_adapter
+from gocam_unwinder.ratchet.model_rules import (
+    build_model_rule_registry,
+    load_true_gocam_ids,
+    make_not_true_gocam_gate,
+    make_skip_prefix_gate,
+    modelstate_gate,
+    parse_true_gocam_report,
+)
+from gocam_unwinder.ratchet.rules import load_rules
+from gocam_unwinder.ratchet.runner import run_stage
+
+RES = Path("resources/test")
+
+_MODELSTATE_TTL = """@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix lego: <http://geneontology.org/lego/> .
+<http://model.geneontology.org/M1> a owl:Ontology ;
+    lego:modelstate "%s" .
+"""
+
+
+def _state_model(tmp_path, name, state):
+    p = tmp_path / name
+    p.write_text(_MODELSTATE_TTL % state)
+    return Item(id=name.replace(".ttl", ""), path=p)
+
+
+def test_modelstate_delete_removed(tmp_path):
+    assert modelstate_gate(None, _state_model(tmp_path, "d.ttl", "delete")).keep is False
+    assert modelstate_gate(None, _state_model(tmp_path, "p.ttl", "production")).keep is True
+
+
+def test_modelstate_missing_is_kept(tmp_path):
+    p = tmp_path / "n.ttl"
+    p.write_text('@prefix owl: <http://www.w3.org/2002/07/owl#> .\n'
+                 '<http://x/M> a owl:Ontology .\n')
+    assert modelstate_gate(None, Item(id="n", path=p)).keep is True
+
+
+def test_skip_prefix_removes_configured():
+    gate = make_skip_prefix_gate(["SYNGO", "R-HSA"])
+    assert gate(None, Item(id="SYNGO_5371")).keep is False
+    assert gate(None, Item(id="R-HSA-9937080")).keep is False
+    assert gate(None, Item(id="MGI_MGI_1100089")).keep is True
+
+
+def test_skip_prefix_matches_on_filename_when_path_present():
+    gate = make_skip_prefix_gate(["SYNGO"])
+    v = gate(None, Item(id="SYNGO_5371", path=RES / "SYNGO_5371.ttl"))
+    assert v.keep is False and v.detail.get("prefix") == "SYNGO"
+
+
+def test_not_true_gocam_removes_members():
+    gate = make_not_true_gocam_gate({"605c123400000001", "abc"})
+    # a model that IS a true GO-CAM is removed (it cannot be a standard annotation)
+    assert gate(None, Item(id="605c123400000001")).keep is False
+    assert gate(None, Item(id="MGI_MGI_1100089")).keep is True
+
+
+def test_not_true_gocam_empty_set_is_noop():
+    gate = make_not_true_gocam_gate(set())
+    assert gate(None, Item(id="anything")).keep is True
+
+
+def test_load_true_gocam_ids_from_file(tmp_path):
+    f = tmp_path / "ids.txt"
+    f.write_text("# header comment\nM1\nM2\n\nM3\n")
+    assert load_true_gocam_ids(f) == {"M1", "M2", "M3"}
+
+
+def test_load_true_gocam_ids_from_dir(tmp_path):
+    d = tmp_path / "go-cams-json"
+    d.mkdir()
+    (d / "M1.json").write_text("{}")
+    (d / "M2.json").write_text("{}")
+    assert load_true_gocam_ids(d) == {"M1", "M2"}
+
+
+# The published pipeline-from-goa filter report (reports/go-cam/02-filter.jsonl):
+# one line per model, status "success" == a true GO-CAM.
+_FILTER_REPORT = (
+    '{"model_id": "0000000300000001", "status": "filtered", "reason": "not prod"}\n'
+    '{"model_id": "5323da1800000002", "status": "success"}\n'
+    '\n'
+    '{"model_id": "5408ded300000003", "status": "filtered", "reason": "not prod"}\n'
+    '{"model_id": "5a5fc23a00000137", "status": "success"}\n'
+)
+
+
+def test_parse_true_gocam_report_keeps_only_success():
+    assert parse_true_gocam_report(_FILTER_REPORT) == {
+        "5323da1800000002", "5a5fc23a00000137"}
+
+
+def test_load_true_gocam_ids_from_jsonl_file(tmp_path):
+    f = tmp_path / "02-filter.jsonl"
+    f.write_text(_FILTER_REPORT)
+    assert load_true_gocam_ids(f) == {"5323da1800000002", "5a5fc23a00000137"}
+
+
+def test_build_registry_resolves_entrypoints():
+    reg = build_model_rule_registry(skip_prefixes=["SYNGO"], true_gocam_ids={"X"})
+    assert set(reg) == {"modelstate_gate", "skip_prefix_gate", "not_true_gocam_gate"}
+    assert reg["skip_prefix_gate"](None, Item(id="SYNGO_1")).keep is False
+    assert reg["not_true_gocam_gate"](None, Item(id="X")).keep is False
+
+
+def test_phase_a_pipeline_through_runner(tmp_path):
+    """Tasks 1-4 together: load the model rules, run them in order through the
+    runner over real resource models, and confirm the surviving set shrinks
+    to just the MGI model (SYNGO + R-HSA removed by skip_prefix)."""
+    registry = build_model_rule_registry(skip_prefixes=["SYNGO", "R-HSA"],
+                                          true_gocam_ids=set())
+    model_rules = load_rules("rules", phase="model")
+    assert [r.id for r in model_rules] == [
+        "modelstate_delete", "skip_prefix", "not_true_gocam", "model_has_activity_edges"]
+
+    items = [Item(id=p.stem, path=p) for p in (
+        RES / "SYNGO_5371.ttl",
+        RES / "R-HSA-9937080.ttl",
+        RES / "MGI_MGI_1100089.ttl",
+    )]
+    manifest = Manifest(items)
+
+    out_dir = tmp_path / "out"
+    for i, rule in enumerate(model_rules):
+        adapter = resolve_adapter(rule, registry)
+        result = run_stage(adapter, manifest, out_dir=out_dir, index=i, stage_id=rule.id)
+        # monotonic at every step
+        assert result.out_count <= result.in_count
+        manifest = result.survivors
+
+    assert manifest.ids == ["MGI_MGI_1100089"]

--- a/tests/test_ratchet_rules.py
+++ b/tests/test_ratchet_rules.py
@@ -1,0 +1,89 @@
+"""Tests for the ratchet rule-manifest loader (Task 1)."""
+
+import pytest
+import yaml
+
+from gocam_unwinder.ratchet.rules import load_rules
+
+
+def _write_rule(d, **fields):
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "rule.yaml").write_text(yaml.safe_dump(fields))
+
+
+def test_load_rules_ordered_and_parsed(tmp_path):
+    rules_dir = tmp_path / "rules"
+    # Written out of lexical order on disk; loader must sort by dir prefix.
+    _write_rule(rules_dir / "10-b", id="b", phase="unit", stage=2,
+                kind="python", entrypoint="b_fn")
+    _write_rule(rules_dir / "00-a", id="a", phase="model", stage=0,
+                kind="python", entrypoint="a_fn")
+
+    rules = load_rules(rules_dir)
+
+    assert [r.id for r in rules] == ["a", "b"]
+    assert rules[0].phase == "model"
+    assert rules[1].kind == "python"
+    assert rules[1].stage == 2
+
+
+def test_phase_filter_and_disabled(tmp_path):
+    rules_dir = tmp_path / "rules"
+    _write_rule(rules_dir / "00-m", id="m", phase="model", kind="python", entrypoint="x")
+    _write_rule(rules_dir / "01-u", id="u", phase="unit", kind="python", entrypoint="y")
+    _write_rule(rules_dir / "02-off", id="off", phase="unit", kind="python",
+                entrypoint="z", enabled=False)
+
+    assert [r.id for r in load_rules(rules_dir, phase="model")] == ["m"]
+    # disabled rule excluded by default
+    assert [r.id for r in load_rules(rules_dir, phase="unit")] == ["u"]
+    assert [r.id for r in load_rules(rules_dir, phase="unit", include_disabled=True)] \
+        == ["u", "off"]
+
+
+def test_sparql_rule_requires_query_rq(tmp_path):
+    rules_dir = tmp_path / "rules"
+    _write_rule(rules_dir / "00-s", id="s", phase="unit", kind="sparql")
+    with pytest.raises(ValueError, match="query.rq"):
+        load_rules(rules_dir)
+
+
+def test_python_rule_requires_entrypoint(tmp_path):
+    rules_dir = tmp_path / "rules"
+    _write_rule(rules_dir / "00-p", id="p", phase="unit", kind="python")
+    with pytest.raises(ValueError, match="entrypoint"):
+        load_rules(rules_dir)
+
+
+def test_bad_phase_and_kind_rejected(tmp_path):
+    rules_dir = tmp_path / "rules"
+    _write_rule(rules_dir / "00-x", id="x", phase="galaxy", kind="python", entrypoint="e")
+    with pytest.raises(ValueError, match="phase"):
+        load_rules(rules_dir)
+
+
+def test_seed_rules_dir_loads():
+    """The committed rules/ dir parses into the full two-level rule set."""
+    model_rules = load_rules("rules", phase="model")
+    unit_rules = load_rules("rules", phase="unit")
+    model_ids = [r.id for r in model_rules]
+    unit_ids = [r.id for r in unit_rules]
+
+    # Phase A gates in dir order; the disabled disconnected example is excluded.
+    assert model_ids[:3] == ["modelstate_delete", "skip_prefix", "not_true_gocam"]
+    assert "model_has_activity_edges" in model_ids
+    assert "model_disconnected_individuals" not in model_ids  # enabled: false
+    assert "model_disconnected_individuals" in [
+        r.id for r in load_rules("rules", phase="model", include_disabled=True)]
+
+    # Phase B: 12 unit checks in tier order; edge_without_evidence is python now.
+    assert len(unit_ids) == 12
+    assert unit_ids[0] == "edge_without_evidence"
+    assert unit_ids[-1] == "inconsistent_evidence"
+    by_id = {r.id: r for r in unit_rules}
+    assert by_id["edge_without_evidence"].kind == "python"
+    assert by_id["edge_without_evidence"].entrypoint == "unit_edge_without_evidence"
+
+    # the enabled SPARQL model rule has its query.rq
+    sparql = next(r for r in model_rules if r.kind == "sparql")
+    assert sparql.query_path.exists()

--- a/tests/test_ratchet_runner.py
+++ b/tests/test_ratchet_runner.py
@@ -1,0 +1,84 @@
+"""Tests for the ratchet staging engine (Task 2)."""
+
+import json
+
+from gocam_unwinder.ratchet.core import Manifest, Verdict
+from gocam_unwinder.ratchet.runner import run_stage
+
+
+class _PredicateAdapter:
+    """A trivial adapter that removes items whose id matches a predicate."""
+
+    def __init__(self, predicate, reason):
+        self.predicate = predicate
+        self.reason = reason
+
+    def apply(self, item, ctx=None):
+        if self.predicate(item.id):
+            return Verdict.reject(self.reason)
+        return Verdict.survive()
+
+
+def _read_jsonl(path):
+    return [json.loads(l) for l in path.read_text().splitlines() if l.strip()]
+
+
+def test_run_stage_partitions_and_reports(tmp_path):
+    manifest = Manifest.of(["a1", "a2", "X3", "X4"])
+    adapter = _PredicateAdapter(lambda i: i.startswith("X"), reason="starts_with_X")
+
+    out = run_stage(adapter, manifest, out_dir=tmp_path, index=1,
+                    stage_id="starts_with_X")
+
+    assert out.survivors.ids == ["a1", "a2"]
+    assert out.rejected_ids == ["X3", "X4"]
+    assert out.in_count == 4 and out.out_count == 2
+
+    report = _read_jsonl(tmp_path / "reports" / "01-starts_with_X.jsonl")
+    assert {r["id"]: r["decision"] for r in report} == {
+        "a1": "keep", "a2": "keep", "X3": "remove", "X4": "remove"}
+    assert all(r["reason"] == "starts_with_X"
+               for r in report if r["decision"] == "remove")
+
+    # survivor manifest round-trips from disk
+    reloaded = Manifest.read(tmp_path / "S01-starts_with_X.manifest.jsonl")
+    assert reloaded.ids == ["a1", "a2"]
+
+    # rejects tsv lists removed items only
+    rejects = (tmp_path / "01-starts_with_X.rejects.tsv").read_text()
+    assert "X3" in rejects and "X4" in rejects and "a1" not in rejects
+
+
+def test_monotonic_invariant_holds(tmp_path):
+    manifest = Manifest.of(["a", "b", "c"])
+    keep_all = _PredicateAdapter(lambda i: False, reason="never")
+    out = run_stage(keep_all, manifest, out_dir=tmp_path, index=0, stage_id="noop")
+    assert out.survivors.ids == ["a", "b", "c"]
+    assert out.out_count <= out.in_count
+
+
+def test_skip_recorded_as_skip_and_keeps_item(tmp_path):
+    class _Skipper:
+        def apply(self, item, ctx=None):
+            return Verdict.skip("ro_not_loaded")
+
+    out = run_stage(_Skipper(), Manifest.of(["a"]), out_dir=tmp_path,
+                    index=2, stage_id="ro_rule")
+    assert out.survivors.ids == ["a"]  # a skipped rule keeps the item
+    report = _read_jsonl(tmp_path / "reports" / "02-ro_rule.jsonl")
+    assert report[0]["decision"] == "skip"
+    assert report[0]["reason"] == "ro_not_loaded"
+
+
+def test_detail_fields_flow_into_report(tmp_path):
+    class _Detailer:
+        def apply(self, item, ctx=None):
+            return Verdict.reject("bad_edge", source="GO:1", predicate="located_in",
+                                  target="GO:2")
+
+    out = run_stage(_Detailer(), Manifest.of(["m1"]), out_dir=tmp_path,
+                    index=3, stage_id="bad_edge")
+    report = _read_jsonl(tmp_path / "reports" / "03-bad_edge.jsonl")
+    assert report[0]["source"] == "GO:1"
+    assert report[0]["predicate"] == "located_in"
+    assert out.rejected_ids == ["m1"]

--- a/tests/test_ratchet_sharding.py
+++ b/tests/test_ratchet_sharding.py
@@ -1,0 +1,92 @@
+"""Tests for parallel sharding + resume (Task 8)."""
+
+import shutil
+from pathlib import Path
+
+from gocam_unwinder.ratchet.cli import (
+    _aggregate_stage_stats,
+    _partition,
+    run_ratchet,
+    run_ratchet_sharded,
+)
+
+RES = Path("resources/test")
+GO_FILE = "target/go_20250601.json"
+RO_FILE = "resources/test/ro_20250723.owl"
+GROUPS_FILE = "resources/test/groups.yaml"
+
+
+def _corpus(tmp_path, names):
+    d = tmp_path / "models"
+    d.mkdir()
+    for name in names:
+        shutil.copy(RES / name, d / name)
+    return d
+
+
+def _lines(path):
+    return [l for l in Path(path).read_text().splitlines() if l.strip()]
+
+
+def test_partition_round_robin():
+    assert _partition([1, 2, 3, 4, 5], 2) == [[1, 3, 5], [2, 4]]
+    assert _partition([1, 2], 3) == [[1], [2], []]  # extra shard is empty
+
+
+def test_aggregate_sums_per_stage():
+    from gocam_unwinder.ratchet.cli import StageStat
+    a = [StageStat("A", 0, "r0", 10, 8), StageStat("A", 1, "r1", 8, 5)]
+    b = [StageStat("A", 0, "r0", 5, 5), StageStat("A", 1, "r1", 5, 4)]
+    merged = _aggregate_stage_stats([a, b])
+    assert [(m.rule_id, m.in_count, m.out_count) for m in merged] == [
+        ("r0", 15, 13), ("r1", 13, 9)]
+
+
+def test_sharded_phase_a_parity_and_resume(tmp_path):
+    names = ["MGI_MGI_1100089.ttl", "R-HSA-9937080.ttl", "SYNGO_5371.ttl",
+             "5b318d0900000481.ttl", "66c7d41500000016.ttl", "61452e3d00000323.ttl"]
+    models = _corpus(tmp_path, names)
+
+    # Single-process Phase A (no ontology -> Phase B skipped, fast).
+    run_ratchet(models, out_dir=tmp_path / "single", skip_prefixes=["SYNGO", "R-HSA"])
+    single = sorted(_lines(tmp_path / "single" / "SA-final.models.manifest.jsonl"))
+
+    # Sharded, 3 ways.
+    sharded = run_ratchet_sharded(models, out_dir=tmp_path / "shard", jobs=3,
+                                  skip_prefixes=["SYNGO", "R-HSA"])
+    merged = sorted(_lines(tmp_path / "shard" / "SA-final.models.manifest.jsonl"))
+
+    # Exactness: sharded == single.
+    assert merged == single
+    # Summary sums: the final Phase A 'Out' equals the survivor count.
+    last_a = [s for s in sharded.stages if s.phase == "A"][-1]
+    assert last_a.out_count == len(merged)
+    # All shards completed (.done markers).
+    assert all((tmp_path / "shard" / "shards" / f"shard-{k:03d}" / ".done").exists()
+               for k in range(3))
+    # Merged reject reports exist (e.g. skip_prefix removed SYNGO + R-HSA).
+    assert (tmp_path / "shard" / "rejects" / "01-skip_prefix.rejects.tsv").exists()
+
+    # Resume: a second run yields identical per-stage counts (shards skipped).
+    again = run_ratchet_sharded(models, out_dir=tmp_path / "shard", jobs=3,
+                                skip_prefixes=["SYNGO", "R-HSA"])
+    assert [(s.phase, s.index, s.in_count, s.out_count) for s in again.stages] == \
+           [(s.phase, s.index, s.in_count, s.out_count) for s in sharded.stages]
+
+
+def test_sharded_full_parity_with_units(tmp_path, builder):
+    """End-to-end: sharded (2 workers, each building its own GO builder) yields
+    the same surviving-unit count as the monolithic classifier."""
+    names = ["MGI_MGI_1100089.ttl", "5b318d0900000481.ttl"]
+    models = _corpus(tmp_path, names)
+    expected = sum(len(builder.parse_ttl(str(RES / n), classify=True).standard_annotations)
+                   for n in names)
+
+    out = tmp_path / "out"
+    run_ratchet_sharded(models, out_dir=out, jobs=2,
+                        go=GO_FILE, ro=RO_FILE, groups=GROUPS_FILE)
+
+    final = _lines(out / "SB-final.units.manifest.jsonl")
+    assert len(final) == expected
+    assert (out / "summary.tsv").exists()
+    assert (out / "rejects").exists()

--- a/tests/test_ratchet_sparql_rules.py
+++ b/tests/test_ratchet_sparql_rules.py
@@ -1,0 +1,50 @@
+"""Tests for the native .rq SPARQL rules (Task 6)."""
+
+from pathlib import Path
+
+from gocam_unwinder.ratchet.core import Item
+from gocam_unwinder.ratchet.engine import resolve_adapter
+from gocam_unwinder.ratchet.rules import load_rules
+
+RES = Path("resources/test")
+
+
+def _model_rule(rule_id):
+    rules = load_rules("rules", phase="model", include_disabled=True)
+    return next(r for r in rules if r.id == rule_id)
+
+
+def test_has_activity_edges_keeps_real_removes_empty(tmp_path):
+    adapter = resolve_adapter(_model_rule("model_has_activity_edges"))
+
+    real = Item(id="MGI_MGI_1100089", path=RES / "MGI_MGI_1100089.ttl")
+    assert adapter.apply(real).keep is True  # has reified OBO edges
+
+    empty = tmp_path / "empty.ttl"
+    empty.write_text('@prefix owl: <http://www.w3.org/2002/07/owl#> .\n'
+                     '<http://model.geneontology.org/E> a owl:Ontology .\n')
+    assert adapter.apply(Item(id="E", path=empty)).keep is False  # no edges -> dropped
+
+
+def test_disconnected_individuals_select_rule(tmp_path):
+    adapter = resolve_adapter(_model_rule("model_disconnected_individuals"))
+
+    # An orphan named individual -> SELECT returns a row -> removed.
+    orphan = tmp_path / "orphan.ttl"
+    orphan.write_text(
+        '@prefix owl: <http://www.w3.org/2002/07/owl#> .\n'
+        '@prefix ex: <http://x/> .\n'
+        'ex:a a owl:NamedIndividual .\n')
+    assert adapter.apply(Item(id="o", path=orphan)).keep is False
+
+    # Two individuals joined by a reified edge -> SELECT empty -> kept.
+    connected = tmp_path / "connected.ttl"
+    connected.write_text(
+        '@prefix owl: <http://www.w3.org/2002/07/owl#> .\n'
+        '@prefix obo: <http://purl.obolibrary.org/obo/> .\n'
+        '@prefix ex: <http://x/> .\n'
+        'ex:a a owl:NamedIndividual .\n'
+        'ex:b a owl:NamedIndividual .\n'
+        '[] a owl:Axiom ; owl:annotatedSource ex:a ;\n'
+        '   owl:annotatedProperty obo:RO_0002333 ; owl:annotatedTarget ex:b .\n')
+    assert adapter.apply(Item(id="c", path=connected)).keep is True

--- a/tests/test_ratchet_unit_rules.py
+++ b/tests/test_ratchet_unit_rules.py
@@ -1,0 +1,96 @@
+"""Tests for Phase B unit-level rules (Task 5).
+
+These reuse the session ``builder`` fixture (GO + RO + groups) from conftest and
+assert that each unit rule, applied to a model's raw annotation units, matches
+the classification the monolithic filter_out_non_std_annotations() produces.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from gocam_unwinder.ratchet.core import Item
+from gocam_unwinder.ratchet.unit_rules import (
+    build_unit_rule_registry,
+    extract_units,
+    make_unit_rule,
+)
+
+RES = Path("resources/test")
+
+
+@pytest.mark.parametrize("model,check_key,expect_fail", [
+    ("66c7d41500000016.ttl", "edge_without_evidence", True),
+    ("MGI_MGI_1100089.ttl", "edge_without_evidence", False),
+    ("5b318d0900000481.ttl", "mf_causal_mf", True),
+    ("enabler_not_gp_example.ttl", "enabler_not_gp", True),
+    ("multi_mf_bp_example.ttl", "multiple_mf_bp", True),
+    ("multi_mf_anatomy_example.ttl", "multiple_mf_anatomy", True),
+    ("bp_cc_relation_example.ttl", "invalid_bp_cc_relation", True),
+    ("gp_cc_relation_example.ttl", "invalid_gp_cc_relation", True),
+    ("mf_cc_relation_example.ttl", "invalid_mf_cc_relation", True),
+    ("gp_bp_relation_example.ttl", "invalid_gp_bp_relation", True),
+    ("mf_bp_relation_example.ttl", "invalid_mf_bp_relation", True),
+])
+def test_unit_rule_matches_classification(builder, model, check_key, expect_fail):
+    units = extract_units(builder, RES / model)
+    rule = make_unit_rule(check_key)
+    any_removed = any(rule(builder, u).keep is False for u in units)
+    assert any_removed is expect_fail
+
+
+def test_unit_rule_reject_carries_labels(builder):
+    """A removal verdict surfaces resolved source/predicate/target labels."""
+    units = extract_units(builder, RES / "enabler_not_gp_example.ttl")
+    rule = make_unit_rule("enabler_not_gp")
+    rejects = [rule(builder, u) for u in units]
+    rejects = [v for v in rejects if v.keep is False]
+    assert rejects, "expected at least one enabler_not_gp removal"
+    v = rejects[0]
+    assert "predicate" in v.detail and "source" in v.detail and "target" in v.detail
+    assert v.detail["flagged_edges"] >= 1
+
+
+def test_ro_dependent_rule_skips_without_ro():
+    """RO-dependent checks skip (keep + record) when no RO is loaded."""
+    class _NoRoCtx:
+        ro_ontology = None
+
+    item = Item(id="x#0")  # payload not touched on the skip path
+    for key in ("mf_causal_mf", "invalid_gp_bp_relation", "invalid_mf_bp_relation"):
+        v = make_unit_rule(key)(_NoRoCtx(), item)
+        assert v.skipped is True and v.keep is True
+        assert v.reason.endswith("_skipped_no_ro")
+
+
+def test_full_classification_parity_via_units(builder):
+    """The union of per-unit rule removals reproduces the monolithic
+    classification: a model's non-standard annotations are exactly the units
+    flagged by at least one unit rule."""
+    model = "5b318d0900000481.ttl"  # has MF-causal->MF (non-standard) + others
+    keys = build_unit_rule_registry()  # all unit rules
+    rules = {k: v for k, v in keys.items()}
+
+    units = extract_units(builder, RES / model)
+    removed_unit_ids = set()
+    for u in units:
+        for rule in rules.values():
+            if rule(builder, u).keep is False:
+                removed_unit_ids.add(u.id)
+                break
+
+    # Classified reference: parse the same model WITH classification.
+    classified = builder.parse_ttl(str(RES / model), classify=True)
+    # Re-extract raw units (same order) to map index -> standard/non-standard.
+    raw = builder.parse_ttl(str(RES / model), classify=False)
+    n_non_standard = len(classified.non_standard_annotations)
+    assert len(removed_unit_ids) == n_non_standard
+    assert len(raw.standard_annotations) - len(removed_unit_ids) == \
+        len(classified.standard_annotations)
+
+
+def test_build_unit_rule_registry_has_all_checks():
+    from gocam_unwinder.gocam_ttl import GoCamGraphBuilder
+    reg = build_unit_rule_registry()
+    assert set(reg) == {f"unit_{k}" for k in GoCamGraphBuilder.UNIT_CHECK_KEYS}
+    assert len(reg) == 12


### PR DESCRIPTION
[bot] Opened by a Claude Code agent on behalf of @kltm.

A two-level, monotonic filtering pipeline that reduces the noctua-models corpus to **standard annotations**, reusing this tool's existing checks. It is additive — the existing `gocam_ttl.py` classification and CLI behavior are unchanged.

## How it works

- **Rules are data** in `rules/` (`NN-name/rule.yaml` [+ `query.rq`]); a thin runner walks them in order, writing each stage's surviving set plus a "what got filtered out" report, then a roll-up summary.
- **Phase A** ratchets whole models — `modelstate`, filename prefix, and **R1 "not a true GO-CAM"** (consumes pipeline-from-goa's published true-GO-CAM set).
- **Phase B** ratchets annotation units through the 13 `gocam_ttl` checks, refactored into independently-runnable `check_<key>()` callables, in cost-ordered stages.
- **Engine:** per-file, in-process rdflib — supporting both Python predicates and standalone `.rq` SPARQL rules. Runs sharded (`--jobs N`) with shard-level resume and an exact merge.
- **Dashboard:** `gocam_unwinder.ratchet.dashboard` builds one self-contained HTML page — the two-phase funnel, per-rule drill-downs, and explorable model axes (modelstate, editorial group, per-model pass rate) with links into the Noctua editor.

## Try it

```
make corpus            # shallow-clone the noctua-models corpus as a sibling
make ratchet JOBS=8    # auto-downloads GO/RO; runs sharded
make ratchet-dashboard # builds target_*/dashboard.html
```

Or `make ratchet-smoke` for a corpus-free check. Details in the README's "Standard-Annotation Ratchet" section; design, rule inventory, and corpus findings in `docs/plans/2026-06-25-standard-annotation-ratchet.md`.

## Notes for reviewers

- Squashed from a local development branch into a single commit.
- **97 tests pass**, including the 42 pre-existing `gocam_ttl` tests — those are unchanged, because the split of `filter_out_non_std_annotations()` into per-check callables is behavior-preserving.
- Runs as an ordinary (non-root) user; the corpus, ontologies, and `groups.yaml` are auto-fetched, and R1 defaults to the public skyhook URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_— Posted by Claude Code agent on behalf of @kltm._
